### PR TITLE
Add TimeoutException

### DIFF
--- a/Tests/NFUnitTestException/NFUnitTestException.nfproj
+++ b/Tests/NFUnitTestException/NFUnitTestException.nfproj
@@ -35,6 +35,9 @@
     <ProjectReference Include="..\TestFramework\TestFramework.nfproj" />
     <ProjectReference Include="..\UnitTestLauncher\UnitTestLauncher.nfproj" />
   </ItemGroup>
+  <ItemGroup>
+    <None Include="nano.runsettings" />
+  </ItemGroup>
   <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.CSharp.targets" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.CSharp.targets')" />
   <ProjectExtensions>
     <ProjectCapabilities>

--- a/Tests/NFUnitTestException/UnitTestExceptionTests.cs
+++ b/Tests/NFUnitTestException/UnitTestExceptionTests.cs
@@ -14,6 +14,15 @@ namespace NFUnitTestException
     public class UnitTestExceptionTests
     {
         [TestMethod]
+        public void TestTimeoutException()
+        {
+            Assert.Throws(typeof(TimeoutException), () =>
+            {
+                throw new TimeoutException();
+            });
+        }
+
+        [TestMethod]
         public void Exc_excep01_Test()
         {
             Debug.WriteLine("This test will confirm that the the thrown exception is caught by the matching catch");

--- a/nanoFramework.CoreLibrary/CoreLibrary.nfproj
+++ b/nanoFramework.CoreLibrary/CoreLibrary.nfproj
@@ -202,6 +202,7 @@
     <Compile Include="System\Threading\SpinWait.cs" />
     <Compile Include="System\Threading\Timer.cs" />
     <Compile Include="System\Threading\WaitHandle.cs" />
+    <Compile Include="System\TimeoutException.cs" />
     <Compile Include="System\TimeSpan.cs" />
     <Compile Include="System\Type.cs" />
     <Compile Include="System\TypeCode.cs" />

--- a/nanoFramework.CoreLibrary/System/AssemblyInfo.cs
+++ b/nanoFramework.CoreLibrary/System/AssemblyInfo.cs
@@ -13,4 +13,4 @@ using System.Reflection;
 [assembly: AssemblyProduct(".NET nanoFramework mscorlib")]
 [assembly: AssemblyCopyright("Copyright (c) .NET Foundation and Contributors")]
 
-[assembly: AssemblyNativeVersion("100.5.0.8")]
+[assembly: AssemblyNativeVersion("100.5.0.9")]

--- a/nanoFramework.CoreLibrary/System/TimeoutException.cs
+++ b/nanoFramework.CoreLibrary/System/TimeoutException.cs
@@ -1,0 +1,41 @@
+﻿//
+// Copyright (c) .NET Foundation and Contributors
+// Portions Copyright (c) Microsoft Corporation.  All rights reserved.
+// See LICENSE file in the project root for full license information.
+//
+
+namespace System
+{
+    /// <summary>
+    /// The exception that is thrown when the time allotted for a process or operation has expired.
+    /// </summary>
+    [Serializable]
+    public class TimeoutException : SystemException
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TimeoutException"/> class.
+        /// </summary>
+        public TimeoutException()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TimeoutException"/> class with a specified error message.
+        /// </summary>
+        /// <param name="message">The message that describes the error.</param>
+        public TimeoutException(String message)
+            : base(message)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TimeoutException"/> class with a specified error message and a reference to the inner exception that is the cause of this exception.
+        /// </summary>
+        /// <param name="message">The error message that explains the reason for the exception.</param>
+        /// <param name="innerException">The exception that is the cause of the current exception. If the innerException parameter is not a null reference (Nothing in Visual Basic), the current exception is raised in a catch block that handles the inner exception.</param>
+        public TimeoutException(String message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+    }
+}


### PR DESCRIPTION
Adding TiemoutException

## Description

Adding TiemoutException

## Motivation and Context

- To better support this exception that was categorized as Exception only
- Because it's used in System.IO.Ports and it's coming and used in this one

## How Has This Been Tested?

- Changes made in nf-interpreter, built image, deployed image on ESP32, ran the new added test on the image, test passed and checked the output to make sure it was properly categorized

## Types of changes

- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [x] Unit Tests (work on Unit Tests, has no impact on code or features)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
