### PR TITLE
Fix access beyond array boundaries in SpanByte

### DIFF
--- a/nanoFramework.CoreLibrary/System/SpanByte.cs
+++ b/nanoFramework.CoreLibrary/System/SpanByte.cs
@@ -42,7 +42,10 @@ namespace System
         {
             if (array != null)
             {
-                if ((length > array.Length - start) || (start > array.Length))
+                if (start < 0 ||
+                    length < 0 ||
+                    start + length > array.Length ||
+                    (start == array.Length && start > 0))
                 {
                     throw new ArgumentOutOfRangeException($"Array length too small");
                 }
@@ -69,7 +72,7 @@ namespace System
         {
             get
             {
-                if (index > _length)
+                if (index >= _length)
                 {
                     throw new ArgumentOutOfRangeException($"Index out of range");
                 }
@@ -78,7 +81,7 @@ namespace System
             }
             set
             {
-                if (index > _length)
+                if (index >= _length)
                 {
                     throw new ArgumentOutOfRangeException($"Index out of range");
                 }
@@ -131,12 +134,7 @@ namespace System
         /// <exception cref="System.ArgumentOutOfRangeException">start is less than zero or greater than System.Span.Length.</exception>
         public SpanByte Slice(int start)
         {
-            if ((start > _length) || (start < 0))
-            {
-                throw new ArgumentOutOfRangeException($"start is less than zero or greater than length");
-            }
-
-            return new SpanByte(_array, _start + start, _length - start);
+            return Slice(start, _length - start);
         }
 
         /// <summary>


### PR DESCRIPTION
## Description

Fix array access similarly to how it's done in https://github.com/nanoframework/nanoFramework.IoT.Device/pull/29

## Motivation and Context
- Fixes a bug

## How Has This Been Tested?<!-- (if applicable) -->

Not tested.

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
