### PR TITLE
ISO8601 compatibility for DateTime ToString

### DIFF
--- a/Tests/NFUnitTestSystemLib/UnitTestDateTime.cs
+++ b/Tests/NFUnitTestSystemLib/UnitTestDateTime.cs
@@ -207,6 +207,98 @@ namespace NFUnitTestSystemLib
         }
 
         [TestMethod]
+        public void DateTime_ToStringTest8()
+        {
+            /// <summary>
+            ///  1. Creates a DateTime
+            ///  2. Verifies DateTime.ToString (String) returns correct String using a specified format
+            /// </summary>
+            OutputHelper.WriteLine("Generating random DateTime");
+
+            DateTime dt = GetRandomDateTime();
+
+            OutputHelper.WriteLine($"Test DateTime is: {dt}");
+
+            OutputHelper.WriteLine("DateTime.ToString(String) using specified formats and Verifying");
+
+            // "o" and "O"
+            string specifier1 = "o";
+            string specifier2 = "O";
+
+            OutputHelper.WriteLine($"Testing specified format(s): '{specifier1}' and '{specifier2}'");
+
+            try
+            {
+                string dtOutput1 = dt.ToString(specifier1);
+                string dtOutput2 = dt.ToString(specifier2);
+
+                OutputHelper.WriteLine($"Output from ToString(\"{specifier1}\") was '{dtOutput1}'");
+                OutputHelper.WriteLine($"Output from ToString(\"{specifier2}\") was '{dtOutput2}'");
+
+                // expected format is yyyy-MM-ddTHH:mm:ss.fffffffZ
+
+                int length = 28;
+
+                // check length
+                Assert.True(length == dtOutput1.Length, $"Wrong output1 length: {dtOutput1.Length}, should have been {length}");
+                Assert.True(length == dtOutput2.Length, $"Wrong output1 length: {dtOutput2.Length}, should have been {length}");
+
+                // check 'yyyy'
+                Assert.Equal(dt.Year, int.Parse(dtOutput1.Substring(0, 4)), "Wrong output1 for 'yyyy'");
+                Assert.Equal(dt.Year, int.Parse(dtOutput2.Substring(0, 4)), "Wrong output2 for 'yyyy'");
+                // check 'MM'
+                Assert.Equal(dt.Month, int.Parse(dtOutput1.Substring(5, 2)), "Wrong output1 in for 'MM'");
+                Assert.Equal(dt.Month, int.Parse(dtOutput2.Substring(5, 2)), "Wrong output2 in for 'MM'");
+                // check 'dd'
+                Assert.Equal(dt.Day, int.Parse(dtOutput1.Substring(8, 2)), "Wrong output1 in for 'dd'");
+                Assert.Equal(dt.Day, int.Parse(dtOutput2.Substring(8, 2)), "Wrong output2 in for 'dd'");
+                // check 'HH'
+                Assert.Equal(dt.Hour, int.Parse(dtOutput1.Substring(11, 2)), "Wrong output1 in for 'HH'");
+                Assert.Equal(dt.Hour, int.Parse(dtOutput2.Substring(11, 2)), "Wrong output2 in for 'HH'");
+                // check 'mm'
+                Assert.Equal(dt.Minute, int.Parse(dtOutput1.Substring(14, 2)), "Wrong output1 in for 'mm'");
+                Assert.Equal(dt.Minute, int.Parse(dtOutput2.Substring(14, 2)), "Wrong output2 in for 'mm'");
+                // check 'ss'
+                Assert.Equal(dt.Second, int.Parse(dtOutput1.Substring(17, 2)), "Wrong output1 in for 'ss'");
+                Assert.Equal(dt.Second, int.Parse(dtOutput2.Substring(17, 2)), "Wrong output2 in for 'ss'");
+
+                // check 'fffffff'
+                // need to do the math to get the fraction part from ticks
+                var fraction = dt.Ticks % _TicksPerSecond;
+                Assert.Equal(fraction, int.Parse(dtOutput1.Substring(20, 7)), "Wrong output1 in for 'fffffff'");
+                Assert.Equal(fraction, int.Parse(dtOutput2.Substring(20, 7)), "Wrong output2 in for 'fffffff'");
+
+                // check '-'
+                Assert.Equal("-", dtOutput1.Substring(4, 1), "Wrong output1 in for '-'");
+                Assert.Equal("-", dtOutput2.Substring(4, 1), "Wrong output2 in for '-'");
+                Assert.Equal("-", dtOutput1.Substring(7, 1), "Wrong output1 in for '-'");
+                Assert.Equal("-", dtOutput2.Substring(7, 1), "Wrong output2 in for '-'");
+                // check 'T'
+                Assert.Equal("T", dtOutput1.Substring(10, 1), "Wrong output1 in for 'T'");
+                Assert.Equal("T", dtOutput2.Substring(10, 1), "Wrong output2 in for 'T'");
+                // check ':'
+                Assert.Equal(":", dtOutput1.Substring(13, 1), "Wrong output1 in for ':'");
+                Assert.Equal(":", dtOutput2.Substring(13, 1), "Wrong output2 in for ':'");
+                Assert.Equal(":", dtOutput1.Substring(16, 1), "Wrong output1 in for ':'");
+                Assert.Equal(":", dtOutput2.Substring(16, 1), "Wrong output2 in for ':'");
+                // check '.'
+                Assert.Equal(".", dtOutput1.Substring(19, 1), "Wrong output1 in for '.'");
+                Assert.Equal(".", dtOutput2.Substring(19, 1), "Wrong output2 in for '.'");
+                // check 'Z'
+                Assert.Equal("Z", dtOutput1.Substring(27, 1), "Wrong output1 in for 'Z'");
+                Assert.Equal("Z", dtOutput2.Substring(27, 1), "Wrong output2 in for 'Z'");
+            }
+            catch (Exception ex)
+            {
+                throw new Exception($"Caught {ex.Message} when Trying DateTime.ToString(\"{specifier1}\")");
+            }
+
+            OutputHelper.WriteLine("");
+
+        }
+
+
+        [TestMethod]
         public void DateTime_AddTest8()
         {
             /// <summary>
@@ -1043,6 +1135,10 @@ namespace NFUnitTestSystemLib
         static int[] leapYear = new int[] {2000, 2004, 2008, 2012, 2016, 2020, 2024, 2028, 2032, 2036, 2040, 2044, 2048,
                 2052, 2056, 2060, 2064, 2068, 2072, 2076, 2080, 2084, 2088, 2092, 2096};
 
+        // computing our constants here, as these are not accessible
+        // equivalent to  DateTime.TicksPerSecond
+        const int _TicksPerSecond = 10000 * 1000;
+
         private DateTime[] Get_ArrayOfRandomDateTimes()
         {
             OutputHelper.WriteLine(DateTime_btwn_1801_And_2801().ToString());
@@ -1085,21 +1181,34 @@ namespace NFUnitTestSystemLib
             Random random = new Random();
             year = random.Next(1399) + 1601;
             month = random.Next(12) + 1;
+
             if (month == 2 && IsLeapYear(year))
+            {
                 day = random.Next(29) + 1;
+            }
             else if (month == 2 && (!IsLeapYear(year)))
+            {
                 day = random.Next(28) + 1;
-            else if (((month <= 7) && ((month + 1) % 2 == 0)) ||
-                ((month > 7) && ((month % 2) == 0)))
+            }
+            else if (((month <= 7) && ((month + 1) % 2 == 0))
+                     || ((month > 7) && ((month % 2) == 0)))
+            {
                 day = random.Next(31) + 1;
+            }
             else
+            {
                 day = random.Next(30) + 1;
+            }
+
             hour = random.Next(24);
             minute = random.Next(60);
             second = random.Next(60);
             millisec = random.Next(1000);
 
-            return new DateTime(year, month, day, hour, minute, second, millisec);
+            DateTime dt = new(year, month, day, hour, minute, second, millisec);
+
+            // fill in random ticks value so we can have a fully filled ticks value
+            return new DateTime(dt.Ticks + random.Next(1000_000));
         }
 
         private DateTime GetLeapYearDateTime()

--- a/nanoFramework.CoreLibrary/System/DateTime.cs
+++ b/nanoFramework.CoreLibrary/System/DateTime.cs
@@ -90,7 +90,7 @@ namespace System
 
         // Number of 100ns ticks per time unit
         private const long TicksPerMillisecond = 10000;
-        private const long TicksPerSecond = TicksPerMillisecond * 1000;
+        internal const long TicksPerSecond = TicksPerMillisecond * 1000;
         private const long TicksPerMinute = TicksPerSecond * 60;
         private const long TicksPerHour = TicksPerMinute * 60;
         private const long TicksPerDay = TicksPerHour * 24;


### PR DESCRIPTION
## Description
Adds `DateTime.ToString("o");` so that ISO8601 compatible datetimes can be generated.

Workarounds from the full framework are:
*  uses the char `Z` instead of the datetime Culture specifier `K` as (I dont think) we support it.
* only supports millisecond precision (as we dont support further decimal places, and would be a waste to add extra zeros).

## Motivation and Context
Option was missing.
- Resolves nanoFramework/Home#853.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [x] Unit Tests (work on Unit Tests, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
