### PR TITLE
Work to support serialization with full .NET

### DIFF
--- a/nanoFramework.CoreLibrary/System/Boolean.cs
+++ b/nanoFramework.CoreLibrary/System/Boolean.cs
@@ -23,7 +23,8 @@ namespace System
 
         // this field is required in the native end
 #pragma warning disable 0649
-        private bool _value;
+        // Do not rename (binary serialization)
+        private bool m_value;
 #pragma warning restore 0649
 
         /// <summary>
@@ -32,7 +33,7 @@ namespace System
         /// <returns>TrueString if the value of this instance is true, or FalseString if the value of this instance is false.</returns>
         public override String ToString()
         {
-            return _value ? TrueString : FalseString;
+            return m_value ? TrueString : FalseString;
         }
 
     }

--- a/nanoFramework.CoreLibrary/System/Byte.cs
+++ b/nanoFramework.CoreLibrary/System/Byte.cs
@@ -16,7 +16,8 @@ namespace System
     {
         // this field is required in the native end
 #pragma warning disable 0649
-        private byte _value;
+        // Do not rename (binary serialization)
+        private byte m_value;
 #pragma warning restore 0649
 
         /// <summary>
@@ -35,7 +36,7 @@ namespace System
         /// <remarks>The return value is formatted with the general numeric format specifier ("G") and the NumberFormatInfo object for the thread current culture.</remarks>
         public override String ToString()
         {
-            return Number.Format(_value, true, "G", NumberFormatInfo.CurrentInfo);
+            return Number.Format(m_value, true, "G", NumberFormatInfo.CurrentInfo);
         }
 
         /// <summary>
@@ -45,7 +46,7 @@ namespace System
         /// <returns>The string representation of the current Byte object, formatted as specified by the format parameter.</returns>
         public String ToString(String format)
         {
-            return Number.Format(_value, true, format, NumberFormatInfo.CurrentInfo);
+            return Number.Format(m_value, true, format, NumberFormatInfo.CurrentInfo);
         }
 
         /// <summary>

--- a/nanoFramework.CoreLibrary/System/Char.cs
+++ b/nanoFramework.CoreLibrary/System/Char.cs
@@ -14,7 +14,8 @@ namespace System
     {
         // this field is required in the native end
 #pragma warning disable 0649
-        private char _value;
+        // Do not rename (binary serialization)
+        private char m_value;
 #pragma warning restore 0649
 
         /// <summary>
@@ -32,7 +33,7 @@ namespace System
         /// <returns>The string representation of the value of this instance.</returns>
         public override String ToString()
         {
-            return new String(_value, 1);
+            return new String(m_value, 1);
         }
 
         /// <summary>
@@ -41,12 +42,12 @@ namespace System
         /// <returns>The lower case character.</returns>
         public char ToLower()
         {
-            if ('A' <= _value && _value <= 'Z')
+            if ('A' <= m_value && m_value <= 'Z')
             {
-                return (char)(_value - ('A' - 'a'));
+                return (char)(m_value - ('A' - 'a'));
             }
 
-            return _value;
+            return m_value;
         }
 
         /// <summary>
@@ -55,12 +56,12 @@ namespace System
         /// <returns>The upper case character.</returns>
         public char ToUpper()
         {
-            if ('a' <= _value && _value <= 'z')
+            if ('a' <= m_value && m_value <= 'z')
             {
-                return (char)(_value + ('A' - 'a'));
+                return (char)(m_value + ('A' - 'a'));
             }
 
-            return _value;
+            return m_value;
         }
     }
 }

--- a/nanoFramework.CoreLibrary/System/Double.cs
+++ b/nanoFramework.CoreLibrary/System/Double.cs
@@ -21,7 +21,8 @@ namespace System
 
         // this field is required in the native end
 #pragma warning disable 0649
-        internal double _value;
+        // Do not rename (binary serialization)
+        internal double m_value;
 #pragma warning restore 0649
 
         /// <summary>
@@ -158,7 +159,7 @@ namespace System
                 return _naNSymbol;
             }
 
-            return Number.Format(_value, false, format, NumberFormatInfo.CurrentInfo);
+            return Number.Format(m_value, false, format, NumberFormatInfo.CurrentInfo);
         }
 
         /// <summary>

--- a/nanoFramework.CoreLibrary/System/Int16.cs
+++ b/nanoFramework.CoreLibrary/System/Int16.cs
@@ -16,7 +16,8 @@ namespace System
     {
         // this field is required in the native end
 #pragma warning disable 0649
-        internal short _value;
+        // Do not rename (binary serialization)
+        internal short m_value;
 #pragma warning restore 0649
 
         /// <summary>
@@ -36,7 +37,7 @@ namespace System
         /// <returns>The string representation of the value of this instance, consisting of a minus sign if the value is negative, and a sequence of digits ranging from 0 to 9 with no leading zeroes.</returns>
         public override String ToString()
         {
-            return Number.Format(_value, true, "G", NumberFormatInfo.CurrentInfo);
+            return Number.Format(m_value, true, "G", NumberFormatInfo.CurrentInfo);
         }
 
         /// <summary>
@@ -46,7 +47,7 @@ namespace System
         /// <returns>The string representation of the value of this instance as specified by format.</returns>
         public String ToString(String format)
         {
-            return Number.Format(_value, true, format, NumberFormatInfo.CurrentInfo);
+            return Number.Format(m_value, true, format, NumberFormatInfo.CurrentInfo);
         }
 
         /// <summary>

--- a/nanoFramework.CoreLibrary/System/Int32.cs
+++ b/nanoFramework.CoreLibrary/System/Int32.cs
@@ -14,7 +14,8 @@ namespace System
     [Serializable]
     public struct Int32
     {
-        internal int _value;
+        // Do not rename (binary serialization)
+        internal int m_value;
 
         /// <summary>
         /// Represents the largest possible value of an Int32. This field is constant.
@@ -33,7 +34,7 @@ namespace System
         /// <returns>The string representation of the value of this instance, consisting of a negative sign if the value is negative, and a sequence of digits ranging from 0 to 9 with no leading zeroes.</returns>
         public override String ToString()
         {
-            return Number.Format(_value, true, "G", NumberFormatInfo.CurrentInfo);
+            return Number.Format(m_value, true, "G", NumberFormatInfo.CurrentInfo);
         }
 
         /// <summary>
@@ -43,7 +44,7 @@ namespace System
         /// <returns>he string representation of the value of this instance as specified by format.</returns>
         public String ToString(String format)
         {
-            return Number.Format(_value, true, format, NumberFormatInfo.CurrentInfo);
+            return Number.Format(m_value, true, format, NumberFormatInfo.CurrentInfo);
         }
 
         /// <summary>

--- a/nanoFramework.CoreLibrary/System/Int64.cs
+++ b/nanoFramework.CoreLibrary/System/Int64.cs
@@ -14,7 +14,8 @@ namespace System
     [Serializable]
     public struct Int64
     {
-        internal long _value;
+        // Do not rename (binary serialization)
+        internal long m_value;
 
         /// <summary>
         /// Represents the largest possible value of an Int64. This field is constant.
@@ -33,7 +34,7 @@ namespace System
         /// <returns>The string representation of the value of this instance, consisting of a minus sign if the value is negative, and a sequence of digits ranging from 0 to 9 with no leading zeroes.</returns>
         public override String ToString()
         {
-            return Number.Format(_value, true, "G", NumberFormatInfo.CurrentInfo);
+            return Number.Format(m_value, true, "G", NumberFormatInfo.CurrentInfo);
         }
 
         /// <summary>
@@ -43,7 +44,7 @@ namespace System
         /// <returns>The string representation of the value of this instance as specified by format.</returns>
         public String ToString(String format)
         {
-            return Number.Format(_value, true, format, NumberFormatInfo.CurrentInfo);
+            return Number.Format(m_value, true, format, NumberFormatInfo.CurrentInfo);
         }
 
         /// <summary>

--- a/nanoFramework.CoreLibrary/System/SByte.cs
+++ b/nanoFramework.CoreLibrary/System/SByte.cs
@@ -16,7 +16,8 @@ namespace System
     {
         // this field is required in the native end
 #pragma warning disable 0649
-        private sbyte _value;
+        // Do not rename (binary serialization)
+        private sbyte m_value;
 #pragma warning restore 0649
 
         /// <summary>
@@ -37,7 +38,7 @@ namespace System
         /// <returns>The string representation of the value of this instance, consisting of a negative sign if the value is negative, and a sequence of digits ranging from 0 to 9 with no leading zeroes.</returns>
         public override String ToString()
         {
-            return Number.Format(_value, true, "G", NumberFormatInfo.CurrentInfo);
+            return Number.Format(m_value, true, "G", NumberFormatInfo.CurrentInfo);
         }
 
         /// <summary>
@@ -47,7 +48,7 @@ namespace System
         /// <returns>The string representation of the value of this instance as specified by format.</returns>
         public String ToString(String format)
         {
-            return Number.Format(_value, true, format, NumberFormatInfo.CurrentInfo);
+            return Number.Format(m_value, true, format, NumberFormatInfo.CurrentInfo);
         }
 
         /// <summary>

--- a/nanoFramework.CoreLibrary/System/Single.cs
+++ b/nanoFramework.CoreLibrary/System/Single.cs
@@ -17,7 +17,8 @@ namespace System
     {
         // this field is required in the native end
 #pragma warning disable 0649
-        internal float _value;
+        // Do not rename (binary serialization)
+        internal float m_value;
 #pragma warning restore 0649
 
         /// <summary>
@@ -159,7 +160,7 @@ namespace System
                 return double._naNSymbol;
             }
 
-            return Number.Format(_value, false, format, NumberFormatInfo.CurrentInfo);
+            return Number.Format(m_value, false, format, NumberFormatInfo.CurrentInfo);
         }
 
         /// <summary>

--- a/nanoFramework.CoreLibrary/System/UInt16.cs
+++ b/nanoFramework.CoreLibrary/System/UInt16.cs
@@ -16,7 +16,8 @@ namespace System
     {
         // this field is required in the native end
 #pragma warning disable 0649
-        private ushort _value;
+        // Do not rename (binary serialization)
+        private ushort m_value;
 #pragma warning restore 0649
 
         /// <summary>
@@ -36,7 +37,7 @@ namespace System
         /// <returns>The string representation of the value of this instance, which consists of a sequence of digits ranging from 0 to 9, without a sign or leading zeros.</returns>
         public override String ToString()
         {
-            return Number.Format(_value, true, "G", NumberFormatInfo.CurrentInfo);
+            return Number.Format(m_value, true, "G", NumberFormatInfo.CurrentInfo);
         }
 
         /// <summary>
@@ -46,7 +47,7 @@ namespace System
         /// <returns>The string representation of the value of this instance as specified by format.</returns>
         public String ToString(String format)
         {
-            return Number.Format(_value, true, format, NumberFormatInfo.CurrentInfo);
+            return Number.Format(m_value, true, format, NumberFormatInfo.CurrentInfo);
         }
 
         /// <summary>

--- a/nanoFramework.CoreLibrary/System/UInt32.cs
+++ b/nanoFramework.CoreLibrary/System/UInt32.cs
@@ -16,7 +16,8 @@ namespace System
     {
         // this field is required in the native end
 #pragma warning disable 0649
-        private uint _value;
+        // Do not rename (binary serialization)
+        private uint m_value;
 #pragma warning restore 0649
 
         /// <summary>
@@ -36,7 +37,7 @@ namespace System
         /// <returns>The string representation of the value of this instance, consisting of a sequence of digits ranging from 0 to 9, without a sign or leading zeroes.</returns>
         public override String ToString()
         {
-            return Number.Format(_value, true, "G", NumberFormatInfo.CurrentInfo);
+            return Number.Format(m_value, true, "G", NumberFormatInfo.CurrentInfo);
         }
 
         /// <summary>
@@ -46,7 +47,7 @@ namespace System
         /// <returns>The string representation of the value of this instance as specified by format.</returns>
         public String ToString(String format)
         {
-            return Number.Format(_value, true, format, NumberFormatInfo.CurrentInfo);
+            return Number.Format(m_value, true, format, NumberFormatInfo.CurrentInfo);
         }
 
         /// <summary>

--- a/nanoFramework.CoreLibrary/System/UInt64.cs
+++ b/nanoFramework.CoreLibrary/System/UInt64.cs
@@ -14,7 +14,11 @@ namespace System
     [Serializable, CLSCompliant(false)]
     public struct UInt64
     {
-        private ulong _value;
+        // this field is required in the native end
+#pragma warning disable 0649        
+        // Do not rename (binary serialization)
+        private ulong m_value;
+#pragma warning restore 0649
 
         /// <summary>
         /// Represents the largest possible value of UInt64. This field is constant.
@@ -33,7 +37,7 @@ namespace System
         /// <returns>The string representation of the value of this instance, consisting of a sequence of digits ranging from 0 to 9, without a sign or leading zeroes.</returns>
         public override String ToString()
         {
-            return Number.Format(_value, true, "G", NumberFormatInfo.CurrentInfo);
+            return Number.Format(m_value, true, "G", NumberFormatInfo.CurrentInfo);
         }
 
         /// <summary>
@@ -43,7 +47,7 @@ namespace System
         /// <returns>The string representation of the value of this instance as specified by format.</returns>
         public String ToString(String format)
         {
-            return Number.Format(_value, true, format, NumberFormatInfo.CurrentInfo);
+            return Number.Format(m_value, true, format, NumberFormatInfo.CurrentInfo);
         }
 
         /// <summary>

--- a/nanoFramework.CoreLibrary/System/Version.cs
+++ b/nanoFramework.CoreLibrary/System/Version.cs
@@ -9,9 +9,11 @@ namespace System
     /// <summary>
     /// Represents the version number of an assembly, operating system, or the common language runtime. This class cannot be inherited.
     /// </summary>
+    [Serializable]
     public sealed class Version // : ICloneable, IComparable, IComparable<Version>, IEquatable<Version>
     {
         // AssemblyName depends on the order staying the same
+        // Do not rename these (binary serialization)
         private readonly int _Major;
         private readonly int _Minor;
         private readonly int _Build = -1;


### PR DESCRIPTION
## Description
- Rename _value fields for base types to match full .NET and allow seamless serialization.
- Add Serializable to Version class.

## Motivation and Context
- Allow seamless serialization with full .NET classes.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
