### PR TITLE
Fixed typo in ToUint32 and ToUint64 description

### DIFF
--- a/nanoFramework.CoreLibrary/System/BitConverter.cs
+++ b/nanoFramework.CoreLibrary/System/BitConverter.cs
@@ -225,7 +225,7 @@ namespace System
         public static extern ushort ToUInt16(byte[] value, int startIndex);
 
         /// <summary>
-        /// Returns a 32-bit unsigned integer converted from two bytes at a specified position in a byte array.
+        /// Returns a 32-bit unsigned integer converted from four bytes at a specified position in a byte array.
         /// </summary>
         /// <param name="value">The array of bytes.</param>
         /// <param name="startIndex">The starting position within value.</param>
@@ -235,7 +235,7 @@ namespace System
         public static extern uint ToUInt32(byte[] value, int startIndex);
 
         /// <summary>
-        /// Returns a 64-bit unsigned integer converted from two bytes at a specified position in a byte array.
+        /// Returns a 64-bit unsigned integer converted from eight bytes at a specified position in a byte array.
         /// </summary>
         /// <param name="value">The array of bytes.</param>
         /// <param name="startIndex">The starting position within value.</param>


### PR DESCRIPTION
## Description
- ToUint32() & ToUint64() comments says it will be converted from TWO bytes. Changed to "four" and "eight" respectively.

## Motivation and Context
- It confuses.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [x] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
- [ ] My code follows the code style of this project (only if there are changes in source code).
- [x] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
