### PR TITLE
Enable destructor and finalizer tests

### DIFF
--- a/.runsettings
+++ b/.runsettings
@@ -11,5 +11,6 @@
    <nanoFrameworkAdapter>
        <Logging>Verbose</Logging>
        <IsRealHardware>False</IsRealHardware>
+	   <RunnerExtraArguments> --forcegc </RunnerExtraArguments>
    </nanoFrameworkAdapter>
 </RunSettings>

--- a/Tests/NFUnitTestClasses/UnitTestDestructorTests.cs
+++ b/Tests/NFUnitTestClasses/UnitTestDestructorTests.cs
@@ -6,8 +6,6 @@
 
 using nanoFramework.TestFramework;
 using System;
-using System.Diagnostics;
-using System.Reflection;
 
 namespace NFUnitTestClasses
 {
@@ -15,92 +13,102 @@ namespace NFUnitTestClasses
     class UnitTestDestructorTests
     {
         // Removing as using something out of mscorlib
-        //[TestMethod]
-        //public void Destructors3_Test()
-        //{
-        //    //Ported from Destructors3.cs
-        //    //  Section 10.11
-        //    //  Destructors implement the actions required to 
-        //    //  destruct the instances of a class.
-        //    // 
-        //    // Note: This test may fail due to lengthy garbage collection, look for Destructor messages in later logs
-        //    Assert.IsTrue(DestructorsTestClass3.testMethod());
-        //}
+        [TestMethod]
+        public void Destructors3_Test()
+        {
+            //Ported from Destructors3.cs
+            //  Section 10.11
+            //  Destructors implement the actions required to 
+            //  destruct the instances of a class.
+            // 
+            // Note: This test may fail due to lengthy garbage collection, look for Destructor messages in later logs
+            Assert.IsTrue(DestructorsTestClass3.TestMethod());
+        }
 
-        //[TestMethod]
-        //public void Destructors4_Test()
-        //{
-        //    //Ported from Destructors4.cs
-        //    //  Section 10.11
-        //    //  Destructors implement the actions required to 
-        //    //  destruct the instances of a class.
-        //    // 
-        //    // Note: This test may fail due to lengthy garbage collection, look for Destructor messages in later logs
-        //    Assert.IsTrue(DestructorsTestClass4.testMethod());
-        //}
+        [TestMethod]
+        public void Destructors4_Test()
+        {
+            //Ported from Destructors4.cs
+            //  Section 10.11
+            //  Destructors implement the actions required to 
+            //  destruct the instances of a class.
+            // 
+            // Note: This test may fail due to lengthy garbage collection, look for Destructor messages in later logs
+            Assert.IsTrue(DestructorsTestClass4.TestMethod());
+        }
 
-        // Removed as using a class out of mscorlib
-        //[TestMethod]
-        //public void Destructors7_Test()
-        //{
-        //    //Ported from Destructors7.cs
-        //    //  Section 10.12
-        //    //  Destructors are not inherited. Thus, a class
-        //    //  has no other destructors than those that are 
-        //    //  actually declared in the class.
-        //    // 
-        //    // Note: This test may fail due to lengthy garbage collection, look for Destructor messages in later logs
-        //    Assert.IsTrue(DestructorsTestClass7.testMethod());
-        //}
+        [TestMethod]
+        public void Destructors7_Test()
+        {
+            //Ported from Destructors7.cs
+            //  Section 10.12
+            //  Destructors are not inherited. Thus, a class
+            //  has no other destructors than those that are 
+            //  actually declared in the class.
+            // 
+            // Note: This test may fail due to lengthy garbage collection, look for Destructor messages in later logs
+            Assert.IsTrue(DestructorsTestClass7.TestMethod());
+        }
 
-        //class DestructorsTestClass3
-        //{
+        public class DestructorsTestClass3
+        {
+            static int intI = 1;
 
-        //    static int intI = 1;
+            ~DestructorsTestClass3()
+            {
+                // Calling Destructor for Test Class 3
+                intI = 2;
 
-        //    ~DestructorsTestClass3()
-        //    {
-        //        // Calling Destructor for Test Class 3
-        //        intI = 2;
-        //    }
+                Console.WriteLine("Calling Destructor for Test Class 3");
+            }
 
-        //    public static bool testMethod()
-        //    {
-        //        DestructorsTestClass3 mc = new DestructorsTestClass3();
-        //        mc = null;
-        //        nanoFramework.Runtime.Native.GC.Run(true);
-        //        int sleepTime = 5000;
-        //        int slept = 0;
-        //        while (intI != 2 && slept < sleepTime)
-        //        {
-        //            System.Threading.Thread.Sleep(10);
-        //            slept += 10;
-        //        }
-        //        // Thread has slept for
-        //        OutputHelper.WriteLine(slept.ToString());
-        //        if (intI == 2)
-        //        {
-        //            return true;
-        //        }
-        //        else
-        //        {
-        //            return false;
-        //        }
-        //    }
-        //}
+            public static bool TestMethod()
+            {
+                DestructorsTestClass3 mc = new DestructorsTestClass3();
+                mc = null;
 
+                // the following call has been "replaced" with the setting commanding a GC run before new allocations, which will have the desired effect of 
+                // nanoFramework.Runtime.Native.GC.Run(true);
 
-        class DestructorsTestClass4_Base
+                int sleepTime = 5000;
+                int slept = 0;
+
+                while (intI != 2 && slept < sleepTime)
+                {
+                    // force GC run caused by memory allocation
+                    var dummyArray = new byte[1024 * 1024 * 1];
+
+                    System.Threading.Thread.Sleep(10);
+                    slept += 10;
+                }
+
+                // Thread has slept for
+                OutputHelper.WriteLine($"Thread as slept for{slept}");
+
+                if (intI == 2)
+                {
+                    return true;
+                }
+                else
+                {
+                    return false;
+                }
+            }
+        }
+
+        public class DestructorsTestClass4_Base
         {
             public static int intI = 2;
             ~DestructorsTestClass4_Base()
             {
-                intI = intI * 2;
                 // Calling Destructor for Test Class 4 Base
+                intI = intI * 2;
+
+                Console.WriteLine("Calling Destructor for Test Class 4 Base");
             }
         }
 
-        class DestructorsTestClass4 : DestructorsTestClass4_Base
+        public class DestructorsTestClass4 : DestructorsTestClass4_Base
         {
 
             ~DestructorsTestClass4()
@@ -109,20 +117,29 @@ namespace NFUnitTestClasses
                 // Calling Destructor for Test Class 4
             }
 
-            public static bool testMethod()
+            public static bool TestMethod()
             {
                 DestructorsTestClass4 mc = new DestructorsTestClass4();
                 mc = null;
+
+                // the following call has been "replaced" with the setting commanding a GC run before new allocations, which will have the desired effect of 
                 // nanoFramework.Runtime.Native.GC.Run(true);
+
                 int sleepTime = 5000;
                 int slept = 0;
+
                 while (intI != 8 && slept < sleepTime)
                 {
+                    // force GC run caused by memory allocation
+                    var dummyArray = new byte[1024 * 1024 * 1];
+
                     System.Threading.Thread.Sleep(10);
                     slept += 10;
                 }
+
                 // Thread has slept for
-                OutputHelper.WriteLine(slept.ToString());
+                OutputHelper.WriteLine($"Thread as slept for{slept}");
+
                 if (intI == 8)
                 {
                     return true;
@@ -134,34 +151,45 @@ namespace NFUnitTestClasses
             }
         }
 
-        class DestructorsTestClass7_Base
+        public class DestructorsTestClass7_Base
         {
             public static int intI = 2;
         }
 
-        class DestructorsTestClass7 : DestructorsTestClass7_Base
+        public class DestructorsTestClass7 : DestructorsTestClass7_Base
         {
 
             ~DestructorsTestClass7()
             {
-                intI = 3;
                 // Calling Destructor for Test Class 7
+                intI = 3;
+
+                Console.WriteLine("Calling Destructor for Test Class 7");
             }
 
-            public static bool testMethod()
+            public static bool TestMethod()
             {
                 DestructorsTestClass7 mc = new DestructorsTestClass7();
                 mc = null;
+
+                // the following call has been "replaced" with the setting commanding a GC run before new allocations, which will have the desired effect of 
                 //nanoFramework.Runtime.Native.GC.Run(true);
+
                 int sleepTime = 5000;
                 int slept = 0;
+
                 while (intI != 3 && slept < sleepTime)
                 {
+                    // force GC run caused by memory allocation
+                    var dummyArray = new byte[1024 * 1024 * 1];
+
                     System.Threading.Thread.Sleep(10);
                     slept += 10;
                 }
+
                 // Thread has slept for
-                OutputHelper.WriteLine(slept.ToString());
+                OutputHelper.WriteLine($"Thread as slept for{slept}");
+
                 if (intI == 3)
                 {
                     return true;

--- a/Tests/NFUnitTestSystemLib/UnitTestGCTest.cs
+++ b/Tests/NFUnitTestSystemLib/UnitTestGCTest.cs
@@ -6,20 +6,19 @@
 
 using nanoFramework.TestFramework;
 using System;
-using System.Diagnostics;
 
 namespace NFUnitTestSystemLib
 {
     [TestClass]
-    class UnitTestGCTest
+    public class UnitTestGCTest
     {
-        class FinalizeObject
+        internal class FinalizeObject
         {
             public static FinalizeObject m_currentInstance = null;
 
             ~FinalizeObject()
             {
-                if (m_hasFinalized1 == false)
+                if (!m_hasFinalized1)
                 {
                     // First finalization
 
@@ -46,130 +45,178 @@ namespace NFUnitTestSystemLib
         static bool m_hasFinalized2 = false;
         static bool m_Test1Result = false;
 
-        //[TestMethod]
-        //public void SystemGC1_Test()
-        //{
-        //    /// <summary>
-        //    /// 1. Create a FinalizeObject.
-        //    /// 2. Release the reference
-        //    /// 3. Allow for GC
-        //    /// 4. Run ReRegisterForFinalize
-        //    /// 5. Allow for GC
-        //    /// 6. Verify that object has been collected
-        //    /// </summary>
-        //    ///
-        //    // Tests ReRegisterForFinalize
-        //    // Create a FinalizeObject.
-        //    FinalizeObject mfo = new FinalizeObject();
-        //    m_hasFinalized1 = false;
-        //    m_hasFinalized2 = false;
+        [TestMethod]
+        public void SystemGC1_Test()
+        {
+            /// <summary>
+            /// 1. Create a FinalizeObject.
+            /// 2. Release the reference
+            /// 3. Allow for GC
+            /// 4. Run ReRegisterForFinalize
+            /// 5. Allow for GC
+            /// 6. Verify that object has been collected
+            /// </summary>
+            ///
+            // Tests ReRegisterForFinalize
+            // Create a FinalizeObject.
+            FinalizeObject mfo = new FinalizeObject();
+            m_hasFinalized1 = false;
+            m_hasFinalized2 = false;
 
-        //    // Release reference
-        //    mfo = null;
+            // Release reference
+            mfo = null;
 
-        //    // Allow GC
-        //    GC.WaitForPendingFinalizers();
-        //    int sleepTime = 1000;
-        //    int slept = 0;
-        //    while (m_hasFinalized1 == false && slept < sleepTime)
-        //    {
-        //        System.Threading.Thread.Sleep(10);
-        //        slept += 10;
-        //    }
-        //    OutputHelper.WriteLine("GC took " + slept);
+            // Allow GC
+            GC.WaitForPendingFinalizers();
 
-        //    // At this point mfo will have gone through the first Finalize.
-        //    // There should now be a reference to mfo in the static
-        //    // FinalizeObject.m_currentInstance field.  Setting this value
-        //    // to null and forcing another garbage collection will now
-        //    // cause the object to Finalize permanently.
-        //    // Reregister and allow for GC
-        //    FinalizeObject.m_currentInstance = null;
-        //    GC.WaitForPendingFinalizers();
-        //    sleepTime = 1000;
-        //    slept = 0;
-        //    while (m_hasFinalized2 == false && slept < sleepTime)
-        //    {
-        //        System.Threading.Thread.Sleep(10);
-        //        slept += 10;
-        //    }
-        //    OutputHelper.WriteLine("GC took " + slept);
+            int sleepTime = 1000;
+            int slept = 0;
 
-        //    m_Test1Result = m_hasFinalized2;
-        //    Assert.IsTrue(m_hasFinalized2);
-        //}
+            while (!m_hasFinalized1 && slept < sleepTime)
+            {
+                // force GC run caused by memory allocation
+                var dummyArray = new byte[1024 * 1024 * 1];
 
-        //[TestMethod]
-        //public void SystemGC2_Test()
-        //{
-        //    /// <summary>
-        //    /// 1. Create a FinalizeObject.
-        //    /// 2. Release the reference
-        //    /// 3. SupressFinalize
-        //    /// 3. Allow for GC
-        //    /// 6. Verify that object has not been collected
-        //    /// </summary>
-        //    ///
-        //    // Tests SuppressFinalize
-        //    // Create a FinalizeObject.
-        //    FinalizeObject mfo = new FinalizeObject();
-        //    m_hasFinalized1 = false;
-        //    m_hasFinalized2 = false;
+                System.Threading.Thread.Sleep(10);
+                slept += 10;
+            }
 
-        //    // Releasing
-        //    System.GC.SuppressFinalize(mfo);
-        //    mfo = null;
+            OutputHelper.WriteLine($"GC took {slept}");
 
-        //    // Allow GC
-        //    GC.WaitForPendingFinalizers();
-        //    int sleepTime = 1000;
-        //    int slept = 0;
-        //    while (m_hasFinalized1 == false && slept < sleepTime)
-        //    {
-        //        System.Threading.Thread.Sleep(10);
-        //        slept += 10;
-        //    }
-        //    OutputHelper.WriteLine("GC took " + slept);
+            // At this point mfo will have gone through the first Finalize.
+            // There should now be a reference to mfo in the static
+            // FinalizeObject.m_currentInstance field.  Setting this value
+            // to null and forcing another garbage collection will now
+            // cause the object to Finalize permanently.
+            // Reregister and allow for GC
+            FinalizeObject.m_currentInstance = null;
 
-        //    Assert.IsFalse(m_hasFinalized1);
-        //}
+            GC.WaitForPendingFinalizers();
 
-        //[TestMethod]
-        //public void SystemGC3_Test()
-        //{
-        //    /// <summary>
-        //    /// 1. Create a FinalizeObject.
-        //    /// 2. Release the reference
-        //    /// 3. SupressFinalize
-        //    /// 3. Allow for GC
-        //    /// 6. Verify that object has not been collected
-        //    /// </summary>
-        //    ///
-        //    // Tests WaitForPendingFinalizers, dependant on test 1
-        //    // will auto-fail if test 1 fails.
-        //    Assert.IsTrue(m_Test1Result);
+            sleepTime = 1000;
+            slept = 0;
 
-        //    // Create a FinalizeObject.
-        //    FinalizeObject mfo = new FinalizeObject();
-        //    m_hasFinalized1 = false;
-        //    m_hasFinalized2 = false;
+            while (!m_hasFinalized2 && slept < sleepTime)
+            {
+                // force GC run caused by memory allocation
+                var dummyArray = new byte[1024 * 1024 * 1];
 
-        //    // Releasing
-        //    mfo = null;
+                System.Threading.Thread.Sleep(10);
+                slept += 10;
+            }
 
-        //    // Wait for GC
-        //    GC.WaitForPendingFinalizers();
-        //    System.GC.WaitForPendingFinalizers();
+            OutputHelper.WriteLine($"GC took {slept}");
 
-        //    // Releasing again
-        //    FinalizeObject.m_currentInstance = null;
+            m_Test1Result = m_hasFinalized2;
+            Assert.IsTrue(m_hasFinalized2);
+        }
 
-        //    // Wait for GC
-        //    GC.WaitForPendingFinalizers();
-        //    System.GC.WaitForPendingFinalizers();
+        [TestMethod]
+        public void SystemGC2_Test()
+        {
+            /// <summary>
+            /// 1. Create a FinalizeObject.
+            /// 2. Release the reference
+            /// 3. SupressFinalize
+            /// 3. Allow for GC
+            /// 6. Verify that object has not been collected
+            /// </summary>
+            ///
+            // Tests SuppressFinalize
+            // Create a FinalizeObject.
+            FinalizeObject mfo = new FinalizeObject();
+            m_hasFinalized1 = false;
+            m_hasFinalized2 = false;
 
-        //    Assert.IsTrue(m_hasFinalized2);
-        //}
+            // Releasing
+            GC.SuppressFinalize(mfo);
+            mfo = null;
 
+            // Allow GC
+            GC.WaitForPendingFinalizers();
+
+            int sleepTime = 1000;
+            int slept = 0;
+
+            while (!m_hasFinalized1 && slept < sleepTime)
+            {
+                // force GC run caused by memory allocation
+                var dummyArray = new byte[1024 * 1024 * 1];
+
+                System.Threading.Thread.Sleep(10);
+                slept += 10;
+            }
+
+            OutputHelper.WriteLine($"GC took {slept}");
+
+            Assert.IsFalse(m_hasFinalized1);
+        }
+
+        [TestMethod]
+        public void SystemGC3_Test()
+        {
+            /// <summary>
+            /// 1. Create a FinalizeObject.
+            /// 2. Release the reference
+            /// 3. SupressFinalize
+            /// 3. Allow for GC
+            /// 6. Verify that object has not been collected
+            /// </summary>
+            ///
+
+            // Tests WaitForPendingFinalizers, dependant on test 1
+            // will auto-fail if test 1 fails.
+            OutputHelper.Write("Tests WaitForPendingFinalizers, dependant on test 1");
+            OutputHelper.WriteLine("will auto-fail if test 1 fails.");
+
+            Assert.IsTrue(m_Test1Result);
+
+            // Create a FinalizeObject.
+            FinalizeObject mfo = new FinalizeObject();
+            m_hasFinalized1 = false;
+            m_hasFinalized2 = false;
+
+            // Releasing
+            mfo = null;
+
+            int sleepTime = 1000;
+            int slept = 0;
+
+            while (!m_hasFinalized1 && slept < sleepTime)
+            {
+                // force GC run caused by memory allocation
+                var dummyArray = new byte[1024 * 1024 * 1];
+
+                System.Threading.Thread.Sleep(10);
+                slept += 10;
+            }
+
+            OutputHelper.WriteLine($"GC took {slept}");
+
+            // Wait for GC
+            GC.WaitForPendingFinalizers();
+
+            // Releasing again
+            FinalizeObject.m_currentInstance = null;
+
+            sleepTime = 1000;
+            slept = 0;
+
+            while (!m_hasFinalized2 && slept < sleepTime)
+            {
+                // force GC run caused by memory allocation
+                var dummyArray = new byte[1024 * 1024 * 1];
+
+                System.Threading.Thread.Sleep(10);
+                slept += 10;
+            }
+
+            OutputHelper.WriteLine($"GC took {slept}");
+
+            // Wait for GC
+            GC.WaitForPendingFinalizers();
+
+            Assert.IsTrue(m_hasFinalized2);
+        }
     }
 }


### PR DESCRIPTION
## Description
- Add back and migrate/update Destructor and Finalizer unit test.
- Update runsettings config to force GC on allocation (required for the destructor unit tests to perform).
- Update runsettings to force GC on each allocation which is required to have these tests running properly. Can be removed if GC call is returned back to mscorlib in the future.

## Motivation and Context
- Following nanoframework/metadata-processor#169.
- Addresses nanoFramework/Home#1354.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [x] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
