### PR TITLE
Fixed order of parameters in several Unit Tests

### DIFF
--- a/Tests/NFUnitTestArithmetic/UnitTestFormat.cs
+++ b/Tests/NFUnitTestArithmetic/UnitTestFormat.cs
@@ -468,7 +468,7 @@ namespace NFUnitTestArithmetic
             }
             else
             {
-                Assert.AreEqual(result, expectedResult, $"The expected result for '{formatString}' on value {valueStr} for type {value.GetType().Name} is '{expectedResult}'");
+                Assert.AreEqual(expectedResult, result, $"The expected result for '{formatString}' on value {valueStr} for type {value.GetType().Name} is '{expectedResult}'");
             }
 
             if (rowData != null)

--- a/Tests/NFUnitTestSystemLib/UnitTestDateTime.cs
+++ b/Tests/NFUnitTestSystemLib/UnitTestDateTime.cs
@@ -2303,7 +2303,7 @@ namespace NFUnitTestSystemLib
                 Assert.AreEqual(DateTime.Parse(dtOutput1).ToString(specifier1), dt.ToString(specifier1), $"DateTime.Parse '{dt}' failed");
 
                 Assert.IsTrue(DateTime.TryParse(dtOutput1, out DateTime result), $"DateTime.TryParse '{dt}' failed");
-                Assert.AreEqual(result.ToString(specifier1), dt.ToString(specifier1), $"DateTime.TryParse '{dt}' returning wrong value: '{result}'");
+                Assert.AreEqual(dt.ToString(specifier1), result.ToString(specifier1), $"DateTime.TryParse '{dt}' returning wrong value: '{result}'");
             }
         }
 
@@ -2324,7 +2324,7 @@ namespace NFUnitTestSystemLib
                 Assert.AreEqual(DateTime.Parse(dtOutput1).ToString(specifier1), dt.ToString(specifier1), $"Parsing DateTime '{dt}' failed");
 
                 Assert.IsTrue(DateTime.TryParse(dtOutput1, out DateTime result), $"DateTime.TryParse '{dt}' failed");
-                Assert.AreEqual(result.ToString(specifier1), dt.ToString(specifier1), $"DateTime.TryParse '{dt}' returning wrong value: '{result}'");
+                Assert.AreEqual(dt.ToString(specifier1), result.ToString(specifier1), $"DateTime.TryParse '{dt}' returning wrong value: '{result}'");
             }
         }
 
@@ -2345,7 +2345,7 @@ namespace NFUnitTestSystemLib
                 Assert.AreEqual(DateTime.Parse(dtOutput1).ToString(specifier1), dt.ToString(specifier1), $"Parsing DateTime '{dt}' failed");
 
                 Assert.IsTrue(DateTime.TryParse(dtOutput1, out DateTime result), $"DateTime.TryParse '{dt}' failed");
-                Assert.AreEqual(result.ToString(specifier1), dt.ToString(specifier1), $"DateTime.TryParse '{dt}' returning wrong value: '{result}'");
+                Assert.AreEqual(dt.ToString(specifier1), result.ToString(specifier1), $"DateTime.TryParse '{dt}' returning wrong value: '{result}'");
             }
         }
 

--- a/Tests/NFUnitTestSystemLib/UnitTestParseTests.cs
+++ b/Tests/NFUnitTestSystemLib/UnitTestParseTests.cs
@@ -346,7 +346,7 @@ namespace NFUnitTestSystemLib
                 Assert.AreEqual(_uInt64[i], result);
 
                 result = ulong.Parse(strArr[i]);
-                Assert.AreEqual(result, _uInt64[i]);
+                Assert.AreEqual(_uInt64[i], result);
             }
 
             //Int32:  -2147483648 --> 2147483647


### PR DESCRIPTION
## Description
- Swapped order of parameters in calls to Assert so that the result and expected value are in the correct order.

## Motivation and Context

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [x] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
