### PR TITLE
Improve attribute constructor handling when calling `Type.GetCustomAttributes()`

### DIFF
--- a/Tests/NFUnitTestAttributes/ConstructorTests.cs
+++ b/Tests/NFUnitTestAttributes/ConstructorTests.cs
@@ -1,0 +1,216 @@
+﻿using System;
+using nanoFramework.TestFramework;
+
+namespace NFUnitTestAttributes
+{
+    [TestClass]
+    public class ConstructorTests
+    {
+        public const int ExpectedIntParameter = 69_420;
+        public const string ExpectedStringParameter = "A string parameter";
+
+        private static void AssertDefaultConstructorIsCalled(object[] attributes)
+        {
+            Assert.IsNotNull(attributes);
+            Assert.AreEqual(1, attributes.Length);
+            Assert.IsInstanceOfType(attributes[0], typeof(DefaultConstructorTestAttribute));
+
+            var testAttribute = (DefaultConstructorTestAttribute)attributes[0];
+
+            Assert.AreEqual(ExpectedIntParameter, testAttribute.IntProperty);
+            Assert.AreEqual(ExpectedStringParameter, testAttribute.StringProperty);
+        }
+
+        private static void AssertSingleParameterConstructorIsCalledWithIntValue(object[] attributes)
+        {
+            Assert.IsNotNull(attributes);
+            Assert.AreEqual(1, attributes.Length);
+            Assert.IsInstanceOfType(attributes[0], typeof(ConstructorParameterTestAttribute));
+
+            var testAttribute = (ConstructorParameterTestAttribute)attributes[0];
+
+            Assert.IsTrue(testAttribute.SingleParameterConstructorCalled);
+            Assert.AreEqual(ExpectedIntParameter, testAttribute.IntProperty);
+            Assert.IsNull(testAttribute.StringProperty);
+        }
+
+        private static void AssertSingleParameterConstructorIsCalledWithStringValue(object[] attributes)
+        {
+            Assert.IsNotNull(attributes);
+            Assert.AreEqual(1, attributes.Length);
+            Assert.IsInstanceOfType(attributes[0], typeof(ConstructorParameterTestAttribute));
+
+            var testAttribute = (ConstructorParameterTestAttribute)attributes[0];
+
+            Assert.IsTrue(testAttribute.SingleParameterConstructorCalled);
+            Assert.AreEqual(0, testAttribute.IntProperty);
+            Assert.AreEqual(ExpectedStringParameter, testAttribute.StringProperty);
+        }
+
+        private static void AssertZeroParameterConstructorIsCalled(object[] attributes)
+        {
+            Assert.IsNotNull(attributes);
+            Assert.AreEqual(1, attributes.Length);
+            Assert.IsInstanceOfType(attributes[0], typeof(ConstructorParameterTestAttribute));
+
+            var testAttribute = (ConstructorParameterTestAttribute)attributes[0];
+
+            Assert.IsTrue(testAttribute.ZeroParameterConstructorCalled);
+            Assert.AreEqual(0, testAttribute.IntProperty);
+            Assert.IsNull(testAttribute.StringProperty);
+        }
+
+        [TestMethod]
+        public void When_Attribute_is_on_a_class_default_constructor_is_called()
+        {
+            var attributes = typeof(DefaultConstructorTestCases).GetCustomAttributes(true);
+
+            AssertDefaultConstructorIsCalled(attributes);
+        }
+
+        [TestMethod]
+        public void When_Attribute_is_on_a_class_single_parameter_constructor_is_called_with_int_value()
+        {
+            var attributes = typeof(IntParameterConstructorTestCases).GetCustomAttributes(true);
+
+            AssertSingleParameterConstructorIsCalledWithIntValue(attributes);
+        }
+
+        [TestMethod]
+        public void When_Attribute_is_on_a_class_single_parameter_constructor_is_called_with_string_value()
+        {
+            var attributes = typeof(StringParameterConstructorTestCases).GetCustomAttributes(true);
+ 
+            AssertSingleParameterConstructorIsCalledWithStringValue(attributes);
+        }
+
+        [TestMethod]
+        public void When_Attribute_is_on_a_class_zero_parameter_constructor_is_called()
+        {
+            var attributes = typeof(ZeroParameterConstructorClass).GetCustomAttributes(true);
+
+            AssertZeroParameterConstructorIsCalled(attributes);
+        }
+
+        [TestMethod]
+        public void When_Attribute_is_on_a_method_default_constructor_is_called()
+        {
+            var attributes = typeof(DefaultConstructorTestCases).GetMethod("TestMethod").GetCustomAttributes(true);
+
+            AssertDefaultConstructorIsCalled(attributes);
+        }
+
+        [TestMethod]
+        public void When_Attribute_is_on_a_method_single_parameter_constructor_is_called_with_int_value()
+        {
+            var attributes = typeof(IntParameterConstructorTestCases).GetMethod("TestMethod").GetCustomAttributes(true);
+
+            AssertSingleParameterConstructorIsCalledWithIntValue(attributes);
+        }
+
+        [TestMethod]
+        public void When_Attribute_is_on_a_method_single_parameter_constructor_is_called_with_string_value()
+        {
+            var attributes = typeof(StringParameterConstructorTestCases).GetMethod("TestMethod").GetCustomAttributes(true);
+
+            AssertSingleParameterConstructorIsCalledWithStringValue(attributes);
+
+        }
+
+        [TestMethod]
+        public void When_Attribute_is_on_a_method_zero_parameter_constructor_is_called()
+        {
+            var attributes = typeof(ZeroParameterConstructorClass).GetMethod("TestMethod").GetCustomAttributes(true);
+
+            AssertZeroParameterConstructorIsCalled(attributes);
+        }
+    }
+
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method | AttributeTargets.Property, AllowMultiple = true, Inherited = true)]
+    public class DefaultConstructorTestAttribute : Attribute
+    {
+        public int IntProperty { get; set; } = ConstructorTests.ExpectedIntParameter;
+        public string StringProperty { get; set; } = ConstructorTests.ExpectedStringParameter;
+    }
+
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method | AttributeTargets.Property, AllowMultiple = true, Inherited = true)]
+    public class ConstructorParameterTestAttribute: Attribute 
+    {
+        public ConstructorParameterTestAttribute()
+        {
+            ZeroParameterConstructorCalled = true;
+        }
+
+        public ConstructorParameterTestAttribute(int value)
+        {
+            SingleParameterConstructorCalled = true;
+            IntProperty = value;
+        }
+
+        public ConstructorParameterTestAttribute(string parameter)
+        {
+            SingleParameterConstructorCalled = true;
+            StringProperty = parameter;
+        }
+
+        public bool ZeroParameterConstructorCalled { get; }
+
+        public int IntProperty { get; set; }
+
+        public bool SingleParameterConstructorCalled { get; set; }
+
+        public string StringProperty { get; set; }
+    }
+
+    [DefaultConstructorTest]
+    public class DefaultConstructorTestCases
+    {
+        [DefaultConstructorTest]
+        public object TestProperty { get; set; }
+
+        [DefaultConstructorTest]
+        public void TestMethod()
+        {
+
+        }
+    }
+
+    [ConstructorParameterTest(ConstructorTests.ExpectedIntParameter)]
+    public class IntParameterConstructorTestCases
+    {
+        [ConstructorParameterTest(ConstructorTests.ExpectedIntParameter)]
+        public object TestProperty { get; set; }
+
+        [ConstructorParameterTest(ConstructorTests.ExpectedIntParameter)]
+        public void TestMethod()
+        {
+
+        }
+    }
+
+    [ConstructorParameterTest(ConstructorTests.ExpectedStringParameter)]
+    public class StringParameterConstructorTestCases
+    {
+        [ConstructorParameterTest(ConstructorTests.ExpectedStringParameter)]
+        public object TestProperty { get; set; }
+
+        [ConstructorParameterTest(ConstructorTests.ExpectedStringParameter)]
+        public void TestMethod()
+        {
+
+        }
+    }
+
+    [ConstructorParameterTest]
+    public class ZeroParameterConstructorClass
+    {
+        [ConstructorParameterTest]
+        public object TestProperty { get; set; }
+
+        [ConstructorParameterTest]
+        public void TestMethod()
+        {
+
+        }
+    }
+}

--- a/Tests/NFUnitTestAttributes/NFUnitTestAttributes.nfproj
+++ b/Tests/NFUnitTestAttributes/NFUnitTestAttributes.nfproj
@@ -24,6 +24,7 @@
   </PropertyGroup>
   <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.props" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.props')" />
   <ItemGroup>
+    <Compile Include="ConstructorTests.cs" />
     <Compile Include="UnitTestAttributesTest1.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/nanoFramework.CoreLibrary/System/Reflection/CustomAttributesHelpers.cs
+++ b/nanoFramework.CoreLibrary/System/Reflection/CustomAttributesHelpers.cs
@@ -21,7 +21,7 @@ namespace System.Reflection
         /// 
         /// <para>
         /// 1st position - The type of the <see cref="Attribute"/><br/>
-        /// 2nd position - The type(s) of the constructor parameters
+        /// 2nd position - The constructor parameter(s) or null
         /// </para>
         ///
         /// <para>

--- a/nanoFramework.CoreLibrary/System/Reflection/CustomAttributesHelpers.cs
+++ b/nanoFramework.CoreLibrary/System/Reflection/CustomAttributesHelpers.cs
@@ -46,15 +46,14 @@ namespace System.Reflection
                 }
                 else
                 {
-
-                    // get the types
-                    Type paramType = rawAttributes[i + 1].GetType();
+                    // get the parameter types
+                    var paramType = rawAttributes[i + 1].GetType();
 
                     // get constructor
-                    ConstructorInfo ctor = objectType.GetConstructor(new Type[] { paramType });
+                    var ctor = objectType.GetConstructor(new Type[] { paramType });
 
                     // get params
-                    object[] ctorParams = new object[] { rawAttributes[i + 1] };
+                    var ctorParams = new[] { rawAttributes[i + 1] };
 
                     if (ctor is null)
                     {
@@ -62,9 +61,9 @@ namespace System.Reflection
                         // rebuild params list 
                         ctorParams = (object[])rawAttributes[i + 1];
 
-                        Type[] paramsTypes = new Type[ctorParams.Length];
+                        var paramsTypes = new Type[ctorParams.Length];
 
-                        for (int p = 0; p < ctorParams.Length; p++)
+                        for (var p = 0; p < ctorParams.Length; p++)
                         {
                             paramsTypes[p] = ctorParams[p].GetType();
                         }

--- a/nanoFramework.CoreLibrary/System/Reflection/CustomAttributesHelpers.cs
+++ b/nanoFramework.CoreLibrary/System/Reflection/CustomAttributesHelpers.cs
@@ -4,7 +4,11 @@
 //
 
 using System.Collections;
+using System.Diagnostics;
 
+// ReSharper disable SuggestVarOrType_Elsewhere
+// ReSharper disable SuggestVarOrType_SimpleTypes
+// ReSharper disable SuggestVarOrType_BuiltInTypes
 namespace System.Reflection
 {
     internal class CustomAttributesHelpers
@@ -40,15 +44,15 @@ namespace System.Reflection
                 return new object[0];
             }
 
-            var attributes = new ArrayList();
+            ArrayList attributes = new ArrayList();
 
             for (var i = 0; i < attributeDefinitions.Length; i += 2)
             {
-                var objectType = attributeDefinitions[i].GetType();
-                var parameterType = attributeDefinitions[i + 1]?.GetType();
+                Type objectType = attributeDefinitions[i].GetType();
+                Type parameterType = attributeDefinitions[i + 1]?.GetType();
 
                 ConstructorInfo constructorInfo;
-                var constructorParameters = new object[0];
+                object[] constructorParameters = new object[0];
 
                 if (parameterType is null)
                 {
@@ -66,7 +70,7 @@ namespace System.Reflection
                         // Check for a constructor with multiple parameters of the correct types
                         constructorParameters = (object[])attributeDefinitions[i + 1];
 
-                        var parameterTypes = new Type[constructorParameters.Length];
+                        Type[] parameterTypes = new Type[constructorParameters.Length];
 
                         for (var p = 0; p < constructorParameters.Length; p++)
                         {
@@ -88,14 +92,12 @@ namespace System.Reflection
                 {
                     attributes.Add(constructorInfo.Invoke(constructorParameters));
                 }
-#if DEBUG
                 else
                 {
                     // If a constructor was not found we're assuming it's a type that hasn't been implemented in nanoFramework
                     // eg: System.Runtime.CompilerServices.NullableContextAttribute
-                    Console.WriteLine($"Attribute type is not found: {attributeDefinitions[i]}");
+                    Debug.WriteLine($"Constructor for Attribute type not found: {attributeDefinitions[i]}");
                 }
-#endif
             }
 
             return (object[])attributes.ToArray(typeof(object));


### PR DESCRIPTION
<!--- In the TITLE (↑↑↑↑ above ↑↑↑↑ **NOT HERE**) provide a general, short summary of your changes -->
<!--- Please DO NOT use references to other PR's or issues -->

## Description
- Invoke default Attribute constructor when retrieving custom attributes.
- Properly handle "unknown" attributes that have been added by the compiler but are not implemented in nanoFramework (eg: Nullable_ attributes)
- Add support for multi-parameter constructors

## Motivation and Context
- Fixes nanoFramework/Home#1584

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [x] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [x] I have added new tests to cover my changes.
