### PR TITLE
Fix `UtcNow` and `Today`

### DIFF
--- a/nanoFramework.CoreLibrary/System/DateTime.cs
+++ b/nanoFramework.CoreLibrary/System/DateTime.cs
@@ -82,9 +82,12 @@ namespace System
 #endif // NANOCLR_REFLECTION
     public struct DateTime
     {
-        /// Our origin is at 1601/01/01:00:00:00.000
-        /// While desktop CLR's origin is at 0001/01/01:00:00:00.000.
-        /// There are 504911232000000000 ticks between them which we are subtracting.
+        // Our origin is at 1601/01/01:00:00:00.000
+        // While desktop CLR's origin is at 0001/01/01:00:00:00.000.
+        // There are 504911232000000000 ticks between them which we are subtracting.
+        //////////////////////////////////////////////////////////////////////////////////////////
+        /// Keep in sync with native define TICKS_AT_ORIGIN @ corlib_native_System_DateTime.cpp //
+        //////////////////////////////////////////////////////////////////////////////////////////
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         private const long _ticksAtOrigin = 504911232000000000;
 
@@ -195,7 +198,7 @@ namespace System
         /// nanoFramework doesn't support local time, only  UTC, so it's not possible to specify <see cref="DateTimeKind.Local"/>.
         /// </remarks>
         public DateTime(long ticks, DateTimeKind kind)
-            :this(ticks)
+            : this(ticks)
         {
             // it's OK to check kind parameter only here 
             // if it's invalid the exception will be thrown anyway and allows the constructor to be reused
@@ -505,8 +508,7 @@ namespace System
         /// </value>
         public static DateTime UtcNow
         {
-            [MethodImpl(MethodImplOptions.InternalCall)]
-            get => new DateTime();
+            get => new DateTime(GetUtcNowAsTicks(), DateTimeKind.Utc);
         }
 
         /// <summary>
@@ -556,8 +558,7 @@ namespace System
         /// </value>
         public static DateTime Today
         {
-            [MethodImpl(MethodImplOptions.InternalCall)]
-            get => new DateTime();
+            get => new DateTime(GetTodayAsTicks(), DateTimeKind.Utc);
         }
 
         /// <summary>
@@ -826,10 +827,10 @@ namespace System
             string s,
             out DateTime result)
         {
-            result = Convert.NativeToDateTime(
-                s,
+            Convert.NativeToDateTime(s,
                 false,
-                out bool success);
+                out bool success,
+                out result);
 
             return success;
         }
@@ -839,5 +840,11 @@ namespace System
 
         [MethodImpl(MethodImplOptions.InternalCall)]
         private extern int GetDateTimePart(DateTimePart part);
+
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        private extern static long GetUtcNowAsTicks();
+
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        private extern static long GetTodayAsTicks();
     }
 }


### PR DESCRIPTION
## Description
- These are now calling a native method that returns the corresponding ticks and instantiates a DateTime with those.

## Motivation and Context
- The current implementation was relying on native code that wasn't correct. With these changes not only the intent is more clear but the correct objects are being created.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- Running mscorlib unit tests locally.

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
