### PR TITLE
Rework datetime handling in Convert

### DIFF
--- a/nanoFramework.CoreLibrary/System/Convert.cs
+++ b/nanoFramework.CoreLibrary/System/Convert.cs
@@ -38,7 +38,7 @@ namespace System
         internal static extern double NativeToDouble(string value, bool throwException, out bool success);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        internal static extern DateTime NativeToDateTime(string value, bool throwException, out bool success);
+        internal static extern void NativeToDateTime(string value, bool throwException, out bool success, out DateTime result);
 
         /// <summary>
         /// Converts the value of the specified 8-bit unsigned integer to an equivalent Boolean value.
@@ -177,10 +177,13 @@ namespace System
         /// </remarks>
         public static DateTime ToDateTime(string value)
         {
-            return NativeToDateTime(
+            NativeToDateTime(
                 value,
                 true,
-                out _);
+                out _,
+                out DateTime result);
+
+            return result;
         }
 
         /// <summary>


### PR DESCRIPTION
## Description
- Native helper method is now using a ref parameter to get DateTime result.

## Motivation and Context
- Turns out that the native code that creates a new DateTime object wasn't working correctly. With this approach we rely on the execution engine properly creating the DateTime object instead of the calling code doing it.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- Running mscorlib unit tests locally.

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
