### PR TITLE
Add null helpers to argument exceptions

### DIFF
--- a/nanoFramework.CoreLibrary.NoReflection/CoreLibrary.NoReflection.nfproj
+++ b/nanoFramework.CoreLibrary.NoReflection/CoreLibrary.NoReflection.nfproj
@@ -37,6 +37,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
     <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
     <RestoreLockedMode Condition="'$(TF_BUILD)' == 'True' or '$(ContinuousIntegrationBuild)' == 'True'">true</RestoreLockedMode>
+    <LangVersion>default</LangVersion>
   </PropertyGroup>
   <PropertyGroup>
     <SignAssembly>true</SignAssembly>

--- a/nanoFramework.CoreLibrary/CoreLibrary.nfproj
+++ b/nanoFramework.CoreLibrary/CoreLibrary.nfproj
@@ -38,6 +38,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
     <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
     <RestoreLockedMode Condition="'$(TF_BUILD)' == 'True' or '$(ContinuousIntegrationBuild)' == 'True'">true</RestoreLockedMode>
+    <LangVersion>default</LangVersion>
   </PropertyGroup>
   <PropertyGroup>
     <SignAssembly>true</SignAssembly>

--- a/nanoFramework.CoreLibrary/System/ArgumentException.cs
+++ b/nanoFramework.CoreLibrary/System/ArgumentException.cs
@@ -4,6 +4,10 @@
 // See LICENSE file in the project root for full license information.
 //
 
+#nullable enable
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+
 namespace System
 {
     /// <summary>
@@ -12,54 +16,55 @@ namespace System
     [Serializable]
     public class ArgumentException : SystemException
     {
-        private String _paramName;
+        // ReSharper disable InconsistentNaming
+        private static readonly string Arg_ArgumentException = "Value does not fall within the expected range.";
+        private static readonly string Arg_ParamName_Name = "(Parameter '%s')";
+        private static readonly string Argument_EmptyString = "The value cannot be an empty string.";
+        // ReSharper restore InconsistentNaming
+
+        private readonly string? _paramName;
 
         /// <summary>
-        /// Initializes a new instance of the ArgumentException class.
+        /// Initializes a new instance of the <see cref="ArgumentException"/> class.
         /// </summary>
-        public ArgumentException()
+        public ArgumentException(): base(Arg_ArgumentException)
         {
         }
 
         /// <summary>
-        /// Initializes a new instance of the ArgumentException class with a specified error message.
-        /// </summary>
-        /// <param name="message">The error message that explains the reason for the exception. </param>
-        public ArgumentException(String message)
-            : base(message)
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the ArgumentException class with a specified error message and a reference to the inner exception that is the cause of this exception.
-        /// </summary>
-        /// <param name="message">The error message that explains the reason for the exception. </param>
-        /// <param name="innerException">The exception that is the cause of the current exception. If the innerException parameter is not a null reference, the current exception is raised in a catch block that handles the inner exception.</param>
-        public ArgumentException(String message, Exception innerException)
-            : base(message, innerException)
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the ArgumentException class with a specified error message, the parameter name, and a reference to the inner exception that is the cause of this exception.
+        /// Initializes a new instance of the <see cref="ArgumentException"/> class with a specified error message.
         /// </summary>
         /// <param name="message">The error message that explains the reason for the exception.</param>
-        /// <param name="paramName">The name of the parameter that caused the current exception. </param>
-        /// <param name="innerException">The exception that is the cause of the current exception. If the innerException parameter is not a null reference, the current exception is raised in a catch block that handles the inner exception. </param>
-        public ArgumentException(String message, String paramName, Exception innerException)
-            : base(message, innerException)
+        public ArgumentException(string? message) : base(message ?? Arg_ArgumentException)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ArgumentException"/> class with a specified error message and a reference to the inner exception that is the cause of this exception.
+        /// </summary>
+        /// <param name="message">The error message that explains the reason for the exception.</param>
+        /// <param name="innerException">The exception that is the cause of the current exception. If the <paramref name="innerException"/> parameter is not a null reference, the current exception is raised in a catch block that handles the inner exception.</param>
+        public ArgumentException(string? message, Exception? innerException) : base(message ?? Arg_ArgumentException, innerException)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ArgumentException"/> class with a specified error message and the name of the parameter that causes this exception.
+        /// </summary>
+        /// <param name="message">The error message that explains the reason for the exception.</param>
+        /// <param name="paramName">The name of the parameter that caused the current exception.</param>
+        public ArgumentException(string? message, string? paramName) : base(message ?? Arg_ArgumentException)
         {
             _paramName = paramName;
         }
 
         /// <summary>
-        /// Initializes a new instance of the ArgumentException class with a specified error message and the name of the parameter that causes this exception.
+        /// Initializes a new instance of the <see cref="ArgumentException"/> class with a specified error message, the parameter name, and a reference to the inner exception that is the cause of this exception.
         /// </summary>
-        /// <param name="message">The error message that explains the reason for the exception. </param>
-        /// <param name="paramName">The name of the parameter that caused the current exception. </param>
-        public ArgumentException(String message, String paramName)
-
-            : base(message)
+        /// <param name="message">The error message that explains the reason for the exception.</param>
+        /// <param name="paramName">The name of the parameter that caused the current exception.</param>
+        /// <param name="innerException">The exception that is the cause of the current exception. If the <paramref name="innerException"/> parameter is not a null reference, the current exception is raised in a catch block that handles the inner exception.</param>
+        public ArgumentException(string? message, string? paramName, Exception? innerException) : base(message ?? Arg_ArgumentException, innerException)
         {
             _paramName = paramName;
         }
@@ -70,13 +75,16 @@ namespace System
         /// <value>
         /// A text string describing the details of the exception.
         /// </value>
-        public override String Message
+        public override string Message
         {
             get
             {
                 var s = base.Message;
-                if (!(_paramName == null || _paramName.Length == 0))
-                    return s + "\n" + "Invalid argument " + "'" + _paramName + "'";
+                if (!string.IsNullOrEmpty(_paramName))
+                {
+                    s += " " + string.Format(Arg_ParamName_Name, _paramName);
+                }
+
                 return s;
             }
         }
@@ -84,13 +92,51 @@ namespace System
         /// <summary>
         /// Gets the name of the parameter that causes this exception.
         /// </summary>
-        /// <value>
-        /// The parameter name.
-        /// </value>
-        public virtual String ParamName
+        /// <value>The parameter name.</value>
+        public virtual string? ParamName => _paramName;
+
+        /// <summary>Throws an exception if <paramref name="argument"/> is null or empty.</summary>
+        /// <param name="argument">The string argument to validate as non-null and non-empty.</param>
+        /// <param name="paramName">The name of the parameter with which <paramref name="argument"/> corresponds.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="argument"/> is null.</exception>
+        /// <exception cref="ArgumentException"><paramref name="argument"/> is empty.</exception>
+        public static void ThrowIfNullOrEmpty([NotNull] string? argument, [CallerArgumentExpression(nameof(argument))] string? paramName = null)
         {
-            get { return _paramName; }
+            if (string.IsNullOrEmpty(argument))
+            {
+                ThrowNullOrEmptyException(argument, paramName);
+            }
         }
 
+        /* TODO: Implement when string.IsNullOrWhiteSpace exists
+        /// <summary>Throws an exception if <paramref name="argument"/> is null, empty, or consists only of white-space characters.</summary>
+        /// <param name="argument">The string argument to validate.</param>
+        /// <param name="paramName">The name of the parameter with which <paramref name="argument"/> corresponds.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="argument"/> is null.</exception>
+        /// <exception cref="ArgumentException"><paramref name="argument"/> is empty or consists only of white-space characters.</exception>
+        public static void ThrowIfNullOrWhiteSpace([NotNull] string? argument, [CallerArgumentExpression(nameof(argument))] string? paramName = null)
+        {
+            if (string.IsNullOrWhiteSpace(argument))
+            {
+                ThrowNullOrWhiteSpaceException(argument, paramName);
+            }
+        }
+        */
+
+        [DoesNotReturn]
+        private static void ThrowNullOrEmptyException(string? argument, string? paramName)
+        {
+            ArgumentNullException.ThrowIfNull(argument, paramName);
+            throw new ArgumentException(Argument_EmptyString, paramName);
+        }
+
+        /* TODO: Implement when string.IsNullOrWhiteSpace exists
+        [DoesNotReturn]
+        private static void ThrowNullOrWhiteSpaceException(string? argument, string? paramName)
+        {
+            ArgumentNullException.ThrowIfNull(argument, paramName);
+            throw new ArgumentException(SR.Argument_EmptyOrWhiteSpaceString, paramName);
+        }
+        */
     }
 }

--- a/nanoFramework.CoreLibrary/System/ArgumentNullException.cs
+++ b/nanoFramework.CoreLibrary/System/ArgumentNullException.cs
@@ -3,6 +3,11 @@
 // Portions Copyright (c) Microsoft Corporation.  All rights reserved.
 // See LICENSE file in the project root for full license information.
 //
+
+#nullable enable
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+
 namespace System
 {
     /// <summary>
@@ -11,23 +16,54 @@ namespace System
     [Serializable]
     public class ArgumentNullException : ArgumentException
     {
-        /// <summary>
-        /// Initializes a new instance of the ArgumentNullException class.
-        /// </summary>
-        public ArgumentNullException()
-        { }
+        // ReSharper disable InconsistentNaming
+        private static readonly string ArgumentNull_Generic = "Value cannot be null.";
+        // ReSharper restore InconsistentNaming
 
         /// <summary>
-        /// Initializes a new instance of the ArgumentNullException class with the name of the parameter that causes this exception.
+        /// Initializes a new instance of the <see cref="ArgumentNullException"/> class.
         /// </summary>
-        /// <param name="argument">The name of the parameter that caused the exception.</param>
-        public ArgumentNullException(string argument) : base(null, argument) { }
+        public ArgumentNullException(): base(ArgumentNull_Generic)
+        {
+        }
 
         /// <summary>
-        /// Initializes an instance of the ArgumentNullException class with a specified error message and the name of the parameter that causes this exception.
+        /// Initializes a new instance of the <see cref="ArgumentNullException"/> class with the name of the parameter that causes this exception.
         /// </summary>
-        /// <param name="paramName">The name of the parameter that caused the exception. </param>
-        /// <param name="message">A message that describes the error. </param>
-        public ArgumentNullException(String paramName, String message) : base(message, paramName) { }
+        /// <param name="paramName">The name of the parameter that caused the exception.</param>
+        public ArgumentNullException(string? paramName) : base(ArgumentNull_Generic, paramName)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ArgumentNullException"/> class with a specified error message and the exception that is the cause of this exception.
+        /// </summary>
+        /// <param name="message">The error message that explains the reason for this exception.</param>
+        /// <param name="innerException">The exception that is the cause of the current exception, or a null reference (Nothing in Visual Basic) if no inner exception is specified.</param>
+        public ArgumentNullException(string? message, Exception? innerException) : base(message ?? ArgumentNull_Generic, innerException)
+        {
+        }
+
+        /// <summary>
+        /// Initializes an instance of the <see cref="ArgumentNullException"/> class with a specified error message and the name of the parameter that causes this exception.
+        /// </summary>
+        /// <param name="paramName">The name of the parameter that caused the exception.</param>
+        /// <param name="message">The error message that explains the reason for this exception.</param>
+        public ArgumentNullException(string? paramName, string? message) : base(message ?? ArgumentNull_Generic, paramName) { }
+
+        /// <summary>Throws an <see cref="ArgumentNullException"/> if <paramref name="argument"/> is null.</summary>
+        /// <param name="argument">The reference type argument to validate as non-null.</param>
+        /// <param name="paramName">The name of the parameter with which <paramref name="argument"/> corresponds.</param>
+        public static void ThrowIfNull([NotNull] object? argument, [CallerArgumentExpression(nameof(argument))] string? paramName = null)
+        {
+            if (argument is null)
+            {
+                Throw(paramName);
+            }
+        }
+
+        [DoesNotReturn]
+        internal static void Throw(string? paramName) =>
+            throw new ArgumentNullException(paramName);
     }
 }

--- a/nanoFramework.CoreLibrary/System/String.cs
+++ b/nanoFramework.CoreLibrary/System/String.cs
@@ -4,6 +4,8 @@
 // See LICENSE file in the project root for full license information.
 //
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace System
 {
     using Runtime.CompilerServices;
@@ -825,7 +827,7 @@ namespace System
         /// </summary>
         /// <param name="value">The string to test.</param>
         /// <returns><see langword="true"/> if the value parameter is <see langword="null"/> or an empty string (""); otherwise, <see langword="false"/>.</returns>
-        public static bool IsNullOrEmpty(string value)
+        public static bool IsNullOrEmpty([NotNullWhen(false)] string value)
         {
             return value == null || value.Length == 0;
         }


### PR DESCRIPTION
<!--- In the TITLE (↑↑↑↑ above ↑↑↑↑ **NOT HERE**) provide a general, short summary of your changes -->
<!--- Please DO NOT use references to other PR's or issues -->

## Description
- Add `ArgumentException.ThrowIfNullOrEmpty`
- Add `ArgumentNullException.ThrowIfNull`
- Add `NotNullWhen` attribute to `string.IsNullOrEmpty`

## Motivation and Context
Bring code inline with desktop CLR

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
Locally

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [x] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
