### PR TITLE
Add NativeProfiled attribute

### DIFF
--- a/nanoFramework.CoreLibrary.NoReflection/CoreLibrary.NoReflection.nfproj
+++ b/nanoFramework.CoreLibrary.NoReflection/CoreLibrary.NoReflection.nfproj
@@ -303,6 +303,9 @@
     <NFMDP_PE_ExcludeClassByName Include="System.Diagnostics.DebuggerTypeProxyAttribute">
       <InProject>false</InProject>
     </NFMDP_PE_ExcludeClassByName>
+    <NFMDP_PE_ExcludeClassByName Include="System.Diagnostics.NativeProfiledAttribute">
+      <InProject>false</InProject>
+    </NFMDP_PE_ExcludeClassByName>
     <NFMDP_PE_ExcludeClassByName Include="System.FlagsAttribute">
       <InProject>false</InProject>
     </NFMDP_PE_ExcludeClassByName>

--- a/nanoFramework.CoreLibrary/CoreLibrary.nfproj
+++ b/nanoFramework.CoreLibrary/CoreLibrary.nfproj
@@ -66,6 +66,7 @@
     <Compile Include="System\AppDomainUnloadedException.cs" />
     <Compile Include="System\ApplicationException.cs" />
     <Compile Include="System\ArgumentException.cs" />
+    <Compile Include="System\Diagnostics\NativeProfiledAttribute.cs" />
     <Compile Include="System\PlatformNotSupportedException.cs" />
     <Compile Include="System\ArgumentNullException.cs" />
     <Compile Include="System\ArgumentOutOfRangeException.cs" />
@@ -246,7 +247,7 @@
     </NFMDP_PE_ExcludeClassByName>
     <NFMDP_PE_ExcludeClassByName Include="System.Diagnostics.CodeAnalysis.DoesNotReturnAttribute">
       <InProject>false</InProject>
-    </NFMDP_PE_ExcludeClassByName>    
+    </NFMDP_PE_ExcludeClassByName>
     <NFMDP_PE_ExcludeClassByName Include="System.Diagnostics.CodeAnalysis.DoesNotReturnIfAttribute">
       <InProject>false</InProject>
     </NFMDP_PE_ExcludeClassByName>
@@ -293,6 +294,9 @@
       <InProject>false</InProject>
     </NFMDP_PE_ExcludeClassByName>
     <NFMDP_PE_ExcludeClassByName Include="System.Diagnostics.DebuggerTypeProxyAttribute">
+      <InProject>false</InProject>
+    </NFMDP_PE_ExcludeClassByName>
+    <NFMDP_PE_ExcludeClassByName Include="System.Diagnostics.NativeProfiledAttribute">
       <InProject>false</InProject>
     </NFMDP_PE_ExcludeClassByName>
     <NFMDP_PE_ExcludeClassByName Include="System.FlagsAttribute">

--- a/nanoFramework.CoreLibrary/System/Diagnostics/NativeProfiledAttribute.cs
+++ b/nanoFramework.CoreLibrary/System/Diagnostics/NativeProfiledAttribute.cs
@@ -1,0 +1,19 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+
+namespace System.Diagnostics
+{
+    /// <summary>
+    /// Indicates that a method will profiled by the runtime, providing it has profiling capabilities enabled.
+    /// </summary>
+    /// <remarks>
+    /// This attribute is exclusive to the .NET nanoFramework runtime and has no effect on other runtimes.
+    /// </remarks>
+    [ExcludeType]
+    [DebuggerNonUserCode]
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Constructor, Inherited = false)]
+    public sealed class NativeProfiledAttribute : Attribute
+    { }
+}


### PR DESCRIPTION
## Description
- Add new class for this attribute.

## Motivation and Context
- This attribute is meant to have the profiler to gather data about a method. Despite the MDP, EE and profiler have provisions to work with such attribute it was never implemented. Not even in .NETMF. 

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- Not possible to test. Still lacking support in MDP and Profiler.

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [x] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [x] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
