### PR TITLE
Add new unit test for Equal with float and double types

### DIFF
--- a/Tests/NFUnitTestSystemLib/UnitTestDouble.cs
+++ b/Tests/NFUnitTestSystemLib/UnitTestDouble.cs
@@ -101,6 +101,12 @@ namespace NFUnitTestSystemLib
                     (double)789,
                     "789",
                     false)
+                new DoubleTestData(
+                    (0.0d),
+                    (-0.0d),
+                    true,
+                    "0.0d should be equal to -0.0d")
+
             };
 
             // Floating point numbers should not be tested for equality
@@ -113,7 +119,8 @@ namespace NFUnitTestSystemLib
                 {
                     Assert.AreEqual(
                         test.Expected,
-                        test.D1.Equals(d2));
+                        test.D1.Equals(d2),
+                        test.AssertMessage);
 
                     if (double.IsNaN((double)test.D1) && double.IsNaN(d2))
                     {
@@ -158,12 +165,18 @@ namespace NFUnitTestSystemLib
             public object D1 { get; }
             public object Value { get; }
             public bool Expected { get; }
+            public string AssertMessage { get; }
 
-            public DoubleTestData(object d1, object value, bool expected)
+            public DoubleTestData(
+                object d1,
+                object value,
+                bool expected,
+                string assertMessage = "")
             {
                 D1 = d1;
                 Value = value;
                 Expected = expected;
+                AssertMessage = assertMessage;
             }
         }
     }

--- a/Tests/NFUnitTestSystemLib/UnitTestSingle.cs
+++ b/Tests/NFUnitTestSystemLib/UnitTestSingle.cs
@@ -101,6 +101,11 @@ namespace NFUnitTestSystemLib
                     (float)789,
                     "789",
                     false),
+                new SingleTestData(
+                    (0.0F),
+                    (-0.0F),
+                    true,
+                    "0.0F should be equal to -0.0F")
             };
 
             // Floating point numbers should not be tested for equality
@@ -114,7 +119,8 @@ namespace NFUnitTestSystemLib
                 {
                     Assert.AreEqual(
                         test.Expected,
-                        test.F1.Equals(f2));
+                        test.F1.Equals(f2),
+                        test.AssertMessage);
 
                     if (float.IsNaN((float)test.F1) && float.IsNaN(f2))
                     {
@@ -152,12 +158,18 @@ namespace NFUnitTestSystemLib
             public object F1 { get; }
             public object Value { get; }
             public bool Expected { get; }
+            public string AssertMessage { get; }
 
-            public SingleTestData(object f1, object value, bool expected)
+            public SingleTestData(
+                object f1,
+                object value,
+                bool expected,
+                string assertMessage = "")
             {
                 F1 = f1;
                 Value = value;
                 Expected = expected;
+                AssertMessage = assertMessage;
             }
         }
     }


### PR DESCRIPTION
## Description
- Add new unit test for Equal with float and double types
- Add new property to test class to show proper assert message.

## Motivation and Context
- Need to add test for error reported at nanoFramework/Home#1563.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- Initial run of unit test will fail:
![image](https://github.com/user-attachments/assets/6d826555-ca2c-42bd-83fd-19f3a41b92f9)
![image](https://github.com/user-attachments/assets/207a2727-8abb-45ca-b477-cfeed5a84812)

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [x] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
