### PR TITLE
Fix inclusion of DefaultMemberAttribute in no reflection version

### DIFF
--- a/nanoFramework.CoreLibrary/System/Reflection/DefaultMemberAttribute.cs
+++ b/nanoFramework.CoreLibrary/System/Reflection/DefaultMemberAttribute.cs
@@ -1,9 +1,7 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Runtime.CompilerServices;
-
-#if NANOCLR_REFLECTION
 
 namespace System.Reflection
 {
@@ -18,17 +16,15 @@ namespace System.Reflection
     [Serializable]
     public sealed class DefaultMemberAttribute : Attribute
     {
-        private readonly String _memberName;
-
         // You must provide the name of the member, this is required
         /// <summary>
         /// Initializes a new instance of the DefaultMemberAttribute class.
         /// </summary>
         /// <param name="memberName">A String containing the name of the member to invoke. This may be a constructor, method, property, or field. 
         /// A suitable invocation attribute must be specified when the member is invoked. The default member of a class can be specified by passing an empty String as the name of the member.</param>
-        public DefaultMemberAttribute(String memberName)
+        public DefaultMemberAttribute(string memberName)
         {
-            _memberName = memberName;
+            MemberName = memberName;
         }
 
         /// <summary>
@@ -37,11 +33,6 @@ namespace System.Reflection
         /// <value>
         /// A string representing the member name.
         /// </value>
-        public String MemberName
-        {
-            get { return _memberName; }
-        }
+        public string MemberName { get; }
     }
 }
-
-#endif // NANOCLR_REFLECTION


### PR DESCRIPTION
## Description
- This has to be included otherwise types with indexers wont' compile properly.
- Code style fixes.
- Move to auto implemented property.

## Motivation and Context

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
