### PR TITLE
Fix types wrongly excluded from metadata

### DIFF
--- a/nanoFramework.CoreLibrary/System/Convert.cs
+++ b/nanoFramework.CoreLibrary/System/Convert.cs
@@ -9,7 +9,6 @@ namespace System
     /// Specifies whether relevant Convert.ToBase64CharArray and Convert.ToBase64String methods insert line breaks in their output.
     /// </summary>
     [Flags]
-    [ExcludeType]
     public enum Base64FormattingOptions
     {
         /// <summary>

--- a/nanoFramework.CoreLibrary/System/DateTime.cs
+++ b/nanoFramework.CoreLibrary/System/DateTime.cs
@@ -17,7 +17,6 @@ namespace System
     /// nanoFramework doesn't support local time, only  UTC, so it's not possible to specify <see cref="Local"/>.
     /// </remarks>
     [Serializable]
-    [ExcludeType]
     public enum DateTimeKind
     {
         /// <summary>

--- a/nanoFramework.CoreLibrary/System/DayOfWeek.cs
+++ b/nanoFramework.CoreLibrary/System/DayOfWeek.cs
@@ -9,7 +9,6 @@ namespace System
     /// Specifies the day of the week.
     /// </summary>
     [Serializable]
-    [ExcludeType]
     public enum DayOfWeek
     {
         /// <summary>

--- a/nanoFramework.CoreLibrary/System/IO/IOException.cs
+++ b/nanoFramework.CoreLibrary/System/IO/IOException.cs
@@ -14,7 +14,6 @@ namespace System.IO
         /// <summary>
         /// Provides values for error codes.
         /// </summary>
-        [ExcludeType]
         public enum IOExceptionErrorCode
         {
             /// <summary>

--- a/nanoFramework.CoreLibrary/System/Reflection/AssemblyNameFlags.cs
+++ b/nanoFramework.CoreLibrary/System/Reflection/AssemblyNameFlags.cs
@@ -13,7 +13,6 @@ namespace System.Reflection
     /// </summary>
     /// <remarks>Available only in mscorlib build with support for System.Reflection.</remarks>
     [Serializable, Flags]
-    [ExcludeType]
     public enum AssemblyNameFlags
     {
         /// <summary>

--- a/nanoFramework.CoreLibrary/System/Reflection/MemberTypes.cs
+++ b/nanoFramework.CoreLibrary/System/Reflection/MemberTypes.cs
@@ -13,7 +13,6 @@ namespace System.Reflection
     /// </summary>
     /// <remarks>Available only in mscorlib build with support for System.Reflection.</remarks>
     [Serializable]
-    [ExcludeType]
     public enum MemberTypes
     {
         /// <summary>


### PR DESCRIPTION
## Description
- Remove `ExcludeType`  atrributes from enums that should be available in the metadata.

## Motivation and Context
- Fixes type resolution issues when trying to use these enums.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
