### PR TITLE
Work on `GC` APIs

### DIFF
--- a/Tests/NFUnitTestGC/TestGC.cs
+++ b/Tests/NFUnitTestGC/TestGC.cs
@@ -1,7 +1,8 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 
+using System;
 using nanoFramework.TestFramework;
 
 namespace NFUnitTestGC
@@ -15,8 +16,6 @@ namespace NFUnitTestGC
             int maxArraySize = 1024 * 32;
             object[] arrays = new object[600];
 
-            // Starting TestGCStress
-
             for (int loop = 0; loop < 100; loop++)
             {
                 OutputHelper.WriteLine($"Running iteration {loop}");
@@ -24,7 +23,7 @@ namespace NFUnitTestGC
                 for (int i = 0; i < arrays.Length - 1;)
                 {
                     OutputHelper.WriteLine($"Alloc array of {maxArraySize} bytes @ pos {i}");
-                    arrays[i++] = new byte[maxArraySize]; ;
+                    arrays[i++] = new byte[maxArraySize];
 
                     OutputHelper.WriteLine($"Alloc array of 64 bytes @ pos {i}");
                     arrays[i++] = new byte[64];
@@ -37,8 +36,35 @@ namespace NFUnitTestGC
                     arrays[i] = null;
                 }
             }
+        }
 
-            // Completed TestGCStress
+        [TestMethod]
+        public void TestGetTotalMemory()
+        {
+            // create several objects
+            object[] objects = new object[100];
+
+            for (int i = 0; i < objects.Length; i++)
+            {
+                objects[i] = new object();
+            }
+
+            // get total memory
+            long totalMemory = GC.GetTotalMemory(false);
+            OutputHelper.WriteLine($"Total memory: {totalMemory} bytes");
+
+            // release objects
+            for (int i = 0; i < objects.Length; i++)
+            {
+                objects[i] = null;
+            }
+
+            // get total memory, forcing full collection
+            long totalMemoryAfterCollection = GC.GetTotalMemory(true);
+            OutputHelper.WriteLine($"Total memory: {totalMemoryAfterCollection} bytes");
+
+            // check if memory was released
+            Assert.IsTrue(totalMemory > totalMemoryAfterCollection, "Memory was not released");
         }
     }
 }

--- a/Tests/NFUnitTestSystemLib/UnitTestGCTest.cs
+++ b/Tests/NFUnitTestSystemLib/UnitTestGCTest.cs
@@ -9,6 +9,11 @@ namespace NFUnitTestSystemLib
     [TestClass]
     public class UnitTestGCTest
     {
+#pragma warning disable S1215 // this is intended to test the GC
+#pragma warning disable S1854 // this is intended to test the GC
+#pragma warning disable S2696 // this is intended to test the GC
+#pragma warning disable S3971 // this is intended to test the GC
+
         internal class FinalizeObject
         {
             public static FinalizeObject m_currentInstance = null;
@@ -54,17 +59,20 @@ namespace NFUnitTestSystemLib
             /// 6. Verify that object has been collected
             /// </summary>
             ///
-            // Tests ReRegisterForFinalize
-            // Create a FinalizeObject.
+
+            OutputHelper.WriteLine("Tests ReRegisterForFinalize");
+            OutputHelper.WriteLine("Create a FinalizeObject.");
+
             FinalizeObject mfo = new FinalizeObject();
             m_hasFinalized1 = false;
             m_hasFinalized2 = false;
 
             // Release reference
+            OutputHelper.WriteLine("Release reference");
             mfo = null;
 
-            // Allow GC
-            GC.WaitForPendingFinalizers();
+            OutputHelper.WriteLine("Allow GC");
+            GC.Collect();
 
             int sleepTime = 1000;
             int slept = 0;
@@ -85,10 +93,10 @@ namespace NFUnitTestSystemLib
             // FinalizeObject.m_currentInstance field.  Setting this value
             // to null and forcing another garbage collection will now
             // cause the object to Finalize permanently.
-            // Reregister and allow for GC
-            FinalizeObject.m_currentInstance = null;
 
-            GC.WaitForPendingFinalizers();
+            OutputHelper.WriteLine("Reregister and allow for GC");
+            FinalizeObject.m_currentInstance = null;
+            GC.Collect();
 
             sleepTime = 1000;
             slept = 0;
@@ -119,18 +127,19 @@ namespace NFUnitTestSystemLib
             /// 6. Verify that object has not been collected
             /// </summary>
             ///
-            // Tests SuppressFinalize
-            // Create a FinalizeObject.
+
+            OutputHelper.WriteLine("Tests SuppressFinalize");
+            OutputHelper.WriteLine("Create a FinalizeObject");
             FinalizeObject mfo = new FinalizeObject();
             m_hasFinalized1 = false;
             m_hasFinalized2 = false;
 
-            // Releasing
+            OutputHelper.WriteLine("Releasing");
             GC.SuppressFinalize(mfo);
             mfo = null;
 
-            // Allow GC
-            GC.WaitForPendingFinalizers();
+            OutputHelper.WriteLine("Allow GC");
+            GC.Collect();
 
             int sleepTime = 1000;
             int slept = 0;
@@ -138,7 +147,7 @@ namespace NFUnitTestSystemLib
             while (!m_hasFinalized1 && slept < sleepTime)
             {
                 // force GC run caused by memory allocation
-                var dummyArray = new byte[1024 * 1024 * 1];
+                _ = new byte[1024 * 1024 * 1];
 
                 System.Threading.Thread.Sleep(10);
                 slept += 10;
@@ -161,59 +170,35 @@ namespace NFUnitTestSystemLib
             /// </summary>
             ///
 
-            // Tests WaitForPendingFinalizers, dependant on test 1
-            // will auto-fail if test 1 fails.
             OutputHelper.Write("Tests WaitForPendingFinalizers, dependant on test 1");
-            OutputHelper.WriteLine("will auto-fail if test 1 fails.");
+            OutputHelper.WriteLine("will fail if test 1 fails.");
 
-            Assert.IsTrue(m_Test1Result);
+            Assert.IsTrue(m_Test1Result, "Can't run this test as SystemGC1_Test has failed.");
 
-            // Create a FinalizeObject.
+            OutputHelper.WriteLine("Create a FinalizeObject");
             FinalizeObject mfo = new FinalizeObject();
             m_hasFinalized1 = false;
             m_hasFinalized2 = false;
 
-            // Releasing
+            OutputHelper.WriteLine("Releasing");
             mfo = null;
 
-            int sleepTime = 1000;
-            int slept = 0;
-
-            while (!m_hasFinalized1 && slept < sleepTime)
-            {
-                // force GC run caused by memory allocation
-                var dummyArray = new byte[1024 * 1024 * 1];
-
-                System.Threading.Thread.Sleep(10);
-                slept += 10;
-            }
-
-            OutputHelper.WriteLine($"GC took {slept}");
-
-            // Wait for GC
+            OutputHelper.WriteLine("Wait for GC");
+            GC.Collect();
             GC.WaitForPendingFinalizers();
 
-            // Releasing again
+            OutputHelper.WriteLine("Releasing again");
             FinalizeObject.m_currentInstance = null;
 
-            sleepTime = 1000;
-            slept = 0;
-
-            while (!m_hasFinalized2 && slept < sleepTime)
-            {
-                // force GC run caused by memory allocation
-                var dummyArray = new byte[1024 * 1024 * 1];
-
-                System.Threading.Thread.Sleep(10);
-                slept += 10;
-            }
-
-            OutputHelper.WriteLine($"GC took {slept}");
-
-            // Wait for GC
+            OutputHelper.WriteLine("Wait for GC");
+            GC.Collect();
             GC.WaitForPendingFinalizers();
 
             Assert.IsTrue(m_hasFinalized2);
         }
     }
+#pragma warning restore S1215 // "GC.Collect" should not be called
+#pragma warning restore S1854 // Unused assignments should be removed
+#pragma warning restore S2696 // Instance members should not write to "static" fields
+#pragma warning restore S3971 // "GC.SuppressFinalize" should not be called
 }

--- a/nanoFramework.CoreLibrary/System/GC.cs
+++ b/nanoFramework.CoreLibrary/System/GC.cs
@@ -1,17 +1,64 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
 
 namespace System
 {
-    using Runtime.CompilerServices;
-
     /// <summary>
     /// Controls the system garbage collector, a service that automatically reclaims unused memory.
     /// </summary>
     public static class GC
     {
+#pragma warning disable S4200 // Native methods should be wrapped
+
+        /// <summary>
+        /// Enables or disables the output of garbage collection messages.
+        /// </summary>
+        /// <param name="enable"><see langword="true"/> to enable the output of GC messages; otherwise, <see langword="false"/>.</param>
+        /// <remarks>
+        /// <para>
+        /// Enabling GC messages may not always result in output, depending on the target build options.
+        /// For example, RTM builds, which remove all non-essential features, may not output these messages.
+        /// </para>
+        /// <para>
+        /// This method is specific of .NET nanoFramework implementation. There is no equivalent in full .NET API.
+        /// </para>
+        /// </remarks>
         [MethodImpl(MethodImplOptions.InternalCall)]
-        private static extern bool AnyPendingFinalizers();
+        public static extern void EnableGCMessages(bool enable);
+
+        /// <summary>
+        /// Retrieves the heap size excluding fragmentation. For example if the total GC heap size is 1MB and fragmentation, ie, space taken up by free objects, takes up 400kB, this API would report 600kB. A parameter indicates whether this method can wait a short interval before returning, to allow the system to collect garbage and finalize objects.
+        /// </summary>
+        /// <param name="forceFullCollection"><see langword="true"/> to indicate that this method can wait for garbage collection and heap compaction to occur before returning; otherwise, <see langword="false"/>.</param>
+        /// <returns>The heap size, in bytes, excluding fragmentation.</returns>
+        public static long GetTotalMemory(bool forceFullCollection) => Run(forceFullCollection);
+
+        /// <summary>
+        /// Requests that the system call the finalizer for the specified object for which <see cref="SuppressFinalize"/> has previously been called.
+        /// </summary>
+        /// <param name="obj">The object that a finalizer must be called for.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="obj"/> is <see langword="null"/>.</exception>
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        public static extern void ReRegisterForFinalize(object obj);
+
+        /// <summary>
+        /// Forces an immediate garbage collection of all generations.
+        /// </summary>
+        /// <remarks>
+        /// Use this method to try to reclaim all memory that is inaccessible. It performs a blocking garbage collection of all generations.
+        /// All objects, regardless of how long they have been in memory, are considered for collection; however, objects that are referenced in managed code are not collected. Use this method to force the system to try to reclaim the maximum amount of available memory.
+        /// </remarks>
+        public static void Collect() => Run(true);
+
+        /// <summary>
+        /// Requests that the common language runtime not call the finalizer for the specified object.
+        /// </summary>
+        /// <param name="obj">The object whose finalizer must not be executed.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="obj"/> is <see langword="null"/>.</exception>
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        public static extern void SuppressFinalize(object obj);
 
         /// <summary>
         /// Suspends the current thread until the thread that is processing the queue of finalizers has emptied that queue.
@@ -21,19 +68,12 @@ namespace System
             while (AnyPendingFinalizers()) Threading.Thread.Sleep(10);
         }
 
-        /// <summary>
-        /// Requests that the system not call the finalizer for the specified object.
-        /// </summary>
-        /// <param name="obj">The object that a finalizer must not be called for. </param>
-        [MethodImpl(MethodImplOptions.InternalCall)]
-        public static extern void SuppressFinalize(Object obj);
+#pragma warning restore S4200 // Native methods should be wrapped
 
-        /// <summary>
-        /// Requests that the system call the finalizer for the specified object for which SuppressFinalize has previously been called.
-        /// </summary>
-        /// <param name="obj">The object that a finalizer must be called for. </param>
         [MethodImpl(MethodImplOptions.InternalCall)]
-        public static extern void ReRegisterForFinalize(Object obj);
+        private static extern bool AnyPendingFinalizers();
 
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        private static extern uint Run(bool compactHeap);
     }
 }


### PR DESCRIPTION
## Description
- Add APIs previsouly in Native.Runtime assembly.
- Add `Collect` and `GetTotalMemory` to follow .NET API.
- `Run` is now private and used in both the new APIs.
- Improve IntelliSense comments.
- Rework GC unit tests to take advantage of the new APIs in GC.
- Add new Unit test to cover `GetTotalMemory`.

## Motivation and Context
- Following nanoframework/nanoFramework.Runtime.Native#148.
- Following full .NET API. 
- These belong in mscorlib and the native implementation which is tight with GC code, always exists. So, there is no point on forcing reference of another assembly (nanoFramework.Runtime.Native) to be able to access all GC related API. Moreover, with these living on another assembly several unit tests related with CG and present in mscorlib can now run properly.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [x] New feature (non-breaking change which adds functionality to code)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [x] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [x] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [x] I have added new tests to cover my changes.
