### PR TITLE
Add `ByRefLikeGenerics` to runtime features

### DIFF
--- a/nanoFramework.CoreLibrary/System/Runtime/CompilerServices/RuntimeFeature.cs
+++ b/nanoFramework.CoreLibrary/System/Runtime/CompilerServices/RuntimeFeature.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 namespace System.Runtime.CompilerServices
@@ -14,16 +14,21 @@ namespace System.Runtime.CompilerServices
         public const string DefaultImplementationsOfInterfaces = nameof(DefaultImplementationsOfInterfaces);
 
         /// <summary>
+        /// Represents a runtime feature where byref-like types can be used in Generic parameters.
+        /// </summary>
+        public const string ByRefLikeGenerics = nameof(ByRefLikeGenerics);
+
+        /// <summary>
         /// Checks whether a certain feature is supported by the Runtime.
         /// </summary>
         public static bool IsSupported(string feature)
         {
-            if (feature == DefaultImplementationsOfInterfaces)
+            return feature switch
             {
-                return true;
-            }
-
-            return false;
+                ByRefLikeGenerics or
+                DefaultImplementationsOfInterfaces => true,
+                _ => false,
+            };
         }
     }
 }


### PR DESCRIPTION
## Description
- Add `ByRefLikeGenerics` to runtime features.
- Rework `IsSupported` to make it cleaner.

## Motivation and Context
- Required to support byref structs in generics.
- Related with nanoframework/Home#782.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- Tested with preview version of nanoCLR.

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [x] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [x] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [ ] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
