### PR TITLE
Add `IsReferenceOrContainsReferences` runtime helper

### DIFF
--- a/Tests/NFUnitTestSystemLib/NFUnitTestSystemLib.nfproj
+++ b/Tests/NFUnitTestSystemLib/NFUnitTestSystemLib.nfproj
@@ -21,9 +21,11 @@
     <IsTestProject>true</IsTestProject>
     <TestProjectType>UnitTest</TestProjectType>
     <TargetFrameworkVersion>v1.0</TargetFrameworkVersion>
+    <LangVersion>13.0</LangVersion>
   </PropertyGroup>
   <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.props" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.props')" />
   <ItemGroup>
+    <Compile Include="RuntimeHelpersTests.cs" />
     <Compile Include="UnitTestNullable.cs" />
     <Compile Include="UnitTestUInt64.cs" />
     <Compile Include="UnitTestUInt32.cs" />

--- a/Tests/NFUnitTestSystemLib/RuntimeHelpersTests.cs
+++ b/Tests/NFUnitTestSystemLib/RuntimeHelpersTests.cs
@@ -1,0 +1,68 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+using nanoFramework.TestFramework;
+
+namespace NFUnitTestSystemLib
+{
+    [TestClass]
+    class RuntimeHelpersTests
+    {
+        [TestMethod]
+        public static void IsReferenceOrContainsReferences()
+        {
+            Assert.IsFalse(RuntimeHelpers.IsReferenceOrContainsReferences<int>());
+            Assert.IsTrue(RuntimeHelpers.IsReferenceOrContainsReferences<string>());
+            Assert.IsFalse(RuntimeHelpers.IsReferenceOrContainsReferences<Guid>());
+            Assert.IsFalse(RuntimeHelpers.IsReferenceOrContainsReferences<StructWithoutReferences>());
+            Assert.IsTrue(RuntimeHelpers.IsReferenceOrContainsReferences<StructWithReferences>());
+            Assert.IsFalse(RuntimeHelpers.IsReferenceOrContainsReferences<RefStructWithoutReferences>());
+            Assert.IsTrue(RuntimeHelpers.IsReferenceOrContainsReferences<RefStructWithReferences>());
+            Assert.IsTrue(RuntimeHelpers.IsReferenceOrContainsReferences<Span<char>>());
+            Assert.IsTrue(RuntimeHelpers.IsReferenceOrContainsReferences<ReadOnlySpan<char>>());
+            //Assert.IsTrue(RuntimeHelpers.IsReferenceOrContainsReferences<RefStructWithRef>());
+            Assert.IsTrue(RuntimeHelpers.IsReferenceOrContainsReferences<RefStructWithNestedRef>());
+        }
+
+        private struct StructWithoutReferences
+        {
+            public int a, b, c;
+        }
+
+        private struct StructWithReferences
+        {
+            public int a, b, c;
+            public object d;
+        }
+
+        private ref struct RefStructWithoutReferences
+        {
+            public int a;
+            public long b;
+        }
+
+        private ref struct RefStructWithReferences
+        {
+            public int a;
+            public object b;
+        }
+
+        // TODO: add after checking viability of ref fields in ref structs
+        //private ref struct RefStructWithRef
+        //{
+        //    public ref int a;
+
+        //    internal RefStructWithRef(ref int aVal)
+        //    {
+        //        a = ref aVal;
+        //    }
+        //}
+
+        private ref struct RefStructWithNestedRef
+        {
+            public Span<char> a;
+        }
+    }
+}

--- a/nanoFramework.CoreLibrary/System/Runtime/CompilerServices/RuntimeHelpers.cs
+++ b/nanoFramework.CoreLibrary/System/Runtime/CompilerServices/RuntimeHelpers.cs
@@ -1,8 +1,10 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 namespace System.Runtime.CompilerServices
 {
+#pragma warning disable S4200 // Native methods should be wrapped
+
     /// <summary>
     /// Provides a set of static methods and properties that provide support for compilers. This class cannot be inherited.
     /// </summary>
@@ -43,5 +45,20 @@ namespace System.Runtime.CompilerServices
             [MethodImpl(MethodImplOptions.InternalCall)]
             get;
         }
+
+#if NANOCLR_REFLECTION
+
+        /// <summary>
+        /// Returns a value that indicates whether the specified type is a reference type or a value type that contains references or by-refs.
+        /// </summary>
+        /// <typeparam name="T">The type.</typeparam>
+        /// <returns><see langword="true"/> if the given type is a reference type or a value type that contains references or by-refs; otherwise, <see langword="false"/>.</returns>
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        public static extern bool IsReferenceOrContainsReferences<T>() where T : allows ref struct;
+
+#endif
+
     }
+
+#pragma warning restore S4200 // Native methods should be wrapped
 }


### PR DESCRIPTION
## Description
- Add `IsReferenceOrContainsReferences` runtime helper.
- Add corresponding unit tests.

## Motivation and Context
- Required for generic collections.
- Related with nanoframework/Home#782.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- Running unit tests in nanoframework/nf-interpreter/pull/3214.

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [x] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [x] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [x] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [x] I have added new tests to cover my changes.
