### PR TITLE
Add tests for FieldInfo.FieldType on array-typed fields

### DIFF
--- a/Tests/NFUnitTestSystemLib/UnitTestTypeTests.cs
+++ b/Tests/NFUnitTestSystemLib/UnitTestTypeTests.cs
@@ -515,5 +515,70 @@ namespace NFUnitTestSystemLib
         //        new object[] { -6 }), -6);
         //}
 
+        class TestObjectWithArrayFields
+        {
+            public byte[] ByteArrayField;
+            public int[] IntArrayField;
+            public string StringField;
+        }
+
+        [TestMethod]
+        public void SystemType13_FieldType_ArrayField_Test()
+        {
+            // Verifies that FieldInfo.FieldType returns the concrete array type (e.g. System.Byte[])
+            // and not the generic System.Array base class for array-typed fields.
+            // Regression test for https://github.com/nanoframework/Home/issues/1624
+
+            Type testType = typeof(TestObjectWithArrayFields);
+
+            // --- byte[] field ---
+            FieldInfo byteArrayField = testType.GetField("ByteArrayField");
+            Assert.IsNotNull(byteArrayField);
+
+            Type byteArrayFieldType = byteArrayField.FieldType;
+            OutputHelper.WriteLine($"ByteArrayField.FieldType.FullName: {byteArrayFieldType.FullName}");
+            Assert.AreEqual("System.Byte[]", byteArrayFieldType.FullName);
+            Assert.IsTrue(byteArrayFieldType.IsArray);
+
+            Type byteElementType = byteArrayFieldType.GetElementType();
+            Assert.IsNotNull(byteElementType);
+            OutputHelper.WriteLine($"ByteArrayField.FieldType.GetElementType().FullName: {byteElementType.FullName}");
+            Assert.AreEqual("System.Byte", byteElementType.FullName);
+
+            // --- int[] field ---
+            FieldInfo intArrayField = testType.GetField("IntArrayField");
+            Assert.IsNotNull(intArrayField);
+
+            Type intArrayFieldType = intArrayField.FieldType;
+            OutputHelper.WriteLine($"IntArrayField.FieldType.FullName: {intArrayFieldType.FullName}");
+            Assert.AreEqual("System.Int32[]", intArrayFieldType.FullName);
+            Assert.IsTrue(intArrayFieldType.IsArray);
+
+            Type intElementType = intArrayFieldType.GetElementType();
+            Assert.IsNotNull(intElementType);
+            OutputHelper.WriteLine($"IntArrayField.FieldType.GetElementType().FullName: {intElementType.FullName}");
+            Assert.AreEqual("System.Int32", intElementType.FullName);
+        }
+
+        [TestMethod]
+        public void SystemType14_FieldType_NonArrayField_Test()
+        {
+            // Verifies that FieldInfo.FieldType still works correctly for non-array fields
+            // and that GetElementType() returns null for non-array types.
+
+            Type testType = typeof(TestObjectWithArrayFields);
+
+            FieldInfo stringField = testType.GetField("StringField");
+            Assert.IsNotNull(stringField);
+
+            Type stringFieldType = stringField.FieldType;
+            OutputHelper.WriteLine($"StringField.FieldType.FullName: {stringFieldType.FullName}");
+            Assert.AreEqual("System.String", stringFieldType.FullName);
+            Assert.IsFalse(stringFieldType.IsArray);
+
+            Type stringElementType = stringFieldType.GetElementType();
+            Assert.IsNull(stringElementType);
+        }
+
     }
 }


### PR DESCRIPTION
## Description

- Add regression tests for `FieldInfo.FieldType` returning the correct concrete array type (e.g. `System.Byte[]`) for array-typed fields.
- Add tests covering `FieldType.GetElementType()` returning the correct element type for array fields and `null` for non-array fields.

## Motivation and Context

- Related to nanoFramework/Home#1624

Companion to the interpreter fix in nanoframework/nf-interpreter#3325.

## How Has This Been Tested?

New test methods added to `Tests/NFUnitTestSystemLib/UnitTestTypeTests.cs`:

- `SystemType13_FieldType_ArrayField_Test`: verifies `FieldType.FullName == "System.Byte[]"`, `IsArray == true`, and `GetElementType().FullName == "System.Byte"` for `byte[]` and `int[]` fields.
- `SystemType14_FieldType_NonArrayField_Test`: verifies non-array field type is still correct and `GetElementType()` returns `null`.

## Screenshots

## Types of changes

- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [x] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:

- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [x] I have added new tests to cover my changes.
