### PR TITLE
Fix unit test for `String.Format()`

### DIFF
--- a/Tests/NFUnitTestArithmetic/UnitTestFormat.cs
+++ b/Tests/NFUnitTestArithmetic/UnitTestFormat.cs
@@ -45,7 +45,7 @@ namespace NFUnitTestArithmetic
         {
             // catch an exception if the format string is null
             string nullFormat = null;
-            Assert.ThrowsException(typeof(NullReferenceException), () => { string.Format(nullFormat, 12345.67); });
+            Assert.ThrowsException(typeof(ArgumentNullException), () => { string.Format(nullFormat, 12345.67); });
         }
 
         [TestMethod]

--- a/nanoFramework.CoreLibrary/System/String.cs
+++ b/nanoFramework.CoreLibrary/System/String.cs
@@ -715,6 +715,7 @@ namespace System
         /// <param name="format">A composite format string</param>
         /// <param name="args">An object array that contains zero or more objects to format.</param>
         /// <returns>A copy of <paramref name="format"/> in which the format items have been replaced by the string representation of the corresponding objects in <paramref name="args"/>.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="format"/> or <paramref name="args"/> is <see langword="null"/>.</exception>"
 #if NANOCLR_REFLECTION
 
 #nullable enable

--- a/nanoFramework.CoreLibrary/System/String.cs
+++ b/nanoFramework.CoreLibrary/System/String.cs
@@ -715,7 +715,7 @@ namespace System
         /// <param name="format">A composite format string</param>
         /// <param name="args">An object array that contains zero or more objects to format.</param>
         /// <returns>A copy of <paramref name="format"/> in which the format items have been replaced by the string representation of the corresponding objects in <paramref name="args"/>.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="format"/> or <paramref name="args"/> is <see langword="null"/>.</exception>"
+        /// <exception cref="ArgumentNullException"><paramref name="format"/> or <paramref name="args"/> is <see langword="null"/>.</exception>
 #if NANOCLR_REFLECTION
 
 #nullable enable


### PR DESCRIPTION
## Description
- Now expecting ArgumentNullException.
- Improve IntelliSense comment to include ArgumentNullException.

## Motivation and Context
- Fixes expected exception to follow .NET behaviour.
- Related with nanoframework/Home#782.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- Unit tests running at nanoframework/nf-interpreter#3338.
- [tested against nanoclr buildId 61048]

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [x] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [x] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [x] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
