### PR TITLE
Improvements in `String` class

### DIFF
--- a/Tests/NFUnitTestArithmetic/UnitTestFormat.cs
+++ b/Tests/NFUnitTestArithmetic/UnitTestFormat.cs
@@ -49,6 +49,13 @@ namespace NFUnitTestArithmetic
         }
 
         [TestMethod]
+        public void StringFormat_NullArgs()
+        {
+            // passing a null params array should throw ArgumentNullException
+            Assert.ThrowsException(typeof(ArgumentNullException), () => { string.Format("{0}", (object[])null); });
+        }
+
+        [TestMethod]
         [DataRow("Left align in 10 chars: {0,-10:N2}: and then more", 1234.5641, "Left align in 10 chars: 1,234.56  : and then more")]
         [DataRow("Right align in 10 chars: {0,10:N2}: and then more", 1234.5641, "Right align in 10 chars:   1,234.56: and then more")]
         public void StringFormat_02(string formatString, double value, string outcomeMessage)

--- a/Tests/NFUnitTestSystemLib/UnitTestStringTests.cs
+++ b/Tests/NFUnitTestSystemLib/UnitTestStringTests.cs
@@ -226,6 +226,32 @@ namespace NFUnitTestSystemLib
         }
 
         [TestMethod]
+        public void TrimNullOrEmpty_Test()
+        {
+            // null or empty trimChars should behave like the no-arg (whitespace-only) overloads
+            string withSpaces = "  hello  ";
+            string noSpaces = "hello";
+            char[] empty = new char[] { };
+
+            // Trim(null) / Trim(empty) → same as Trim()
+            Assert.AreEqual(withSpaces.Trim(null), "hello", "Trim(null) should remove whitespace");
+            Assert.AreEqual(withSpaces.Trim(empty), "hello", "Trim(empty) should remove whitespace");
+
+            // TrimStart(null) / TrimStart(empty) → same as TrimStart()
+            Assert.AreEqual(withSpaces.TrimStart(null), "hello  ", "TrimStart(null) should remove leading whitespace");
+            Assert.AreEqual(withSpaces.TrimStart(empty), "hello  ", "TrimStart(empty) should remove leading whitespace");
+
+            // TrimEnd(null) / TrimEnd(empty) → same as TrimEnd()
+            Assert.AreEqual(withSpaces.TrimEnd(null), "  hello", "TrimEnd(null) should remove trailing whitespace");
+            Assert.AreEqual(withSpaces.TrimEnd(empty), "  hello", "TrimEnd(empty) should remove trailing whitespace");
+
+            // Nothing to trim → original value returned
+            Assert.AreEqual(noSpaces.Trim(), "hello", "Trim() on string with no whitespace should return same value");
+            Assert.AreEqual(noSpaces.TrimStart(), "hello", "TrimStart() on string with no whitespace should return same value");
+            Assert.AreEqual(noSpaces.TrimEnd(), "hello", "TrimEnd() on string with no whitespace should return same value");
+        }
+
+        [TestMethod]
         public void IndexOf_Test28()
         {
             // Testing the IndexOf method

--- a/nanoFramework.CoreLibrary/System/String.cs
+++ b/nanoFramework.CoreLibrary/System/String.cs
@@ -48,7 +48,7 @@ namespace System
         /// <returns>true if obj is a String and its value is the same as this instance; otherwise, false. If obj is null, the method returns false.</returns>
         public override bool Equals(object obj)
         {
-            var s = obj as string;
+            string s = obj as string;
             return s != null && Equals(this, s);
         }
 
@@ -62,7 +62,7 @@ namespace System
 
 #nullable enable
         [MethodImpl(MethodImplOptions.InternalCall)]
-        public static extern bool Equals(string a, string b);
+        public static extern bool Equals(string? a, string? b);
 #nullable restore
 
 #else
@@ -215,17 +215,17 @@ namespace System
 #nullable enable
 
         /// <summary>
-        /// Removes all the leading occurrences of a set of characters specified in an array from the current string.
+        /// Removes all leading and trailing occurrences of a set of characters specified in an array from the current string.
         /// </summary>
         /// <param name="trimChars">An array of Unicode characters to remove, or <see langword="null"/>.</param>
-        /// <returns>The string that remains after all occurrences of characters in the <paramref name="trimChars"/> parameter are removed from the start of the current string. If <paramref name="trimChars"/> is <see langword="null"/> or an empty array, white-space characters are removed instead. If no characters can be trimmed from the current instance, the method returns the current instance unchanged.</returns>
+        /// <returns>The string that remains after all occurrences of characters in the <paramref name="trimChars"/> parameter are removed from the start and end of the current string. If <paramref name="trimChars"/> is <see langword="null"/> or an empty array, white-space characters are removed instead. If no characters can be trimmed from the current instance, the method returns the current instance unchanged.</returns>
         [MethodImpl(MethodImplOptions.InternalCall)]
         public extern string Trim(params char[]? trimChars);
 
         /// <summary>
-        /// Removes all the leading occurrences of a set of characters specified in an array from the current string.
+        /// Removes all leading white-space characters from the current string.
         /// </summary>
-        /// <returns>The string that remains after all occurrences of characters in the trimChars parameter are removed from the start of the current string. If trimChars is null or an empty array, white-space characters are removed instead.</returns>
+        /// <returns>The string that remains after all white-space characters are removed from the start of the current string. If no characters can be trimmed from the current instance, the method returns the current instance unchanged.</returns>
         [MethodImpl(MethodImplOptions.InternalCall)]
         public extern string TrimStart();
 
@@ -238,7 +238,7 @@ namespace System
         public extern string TrimStart(params char[]? trimChars);
 
         /// <summary>
-        /// Removes all the trailing occurrences of a set of characters specified in an array from the current string.
+        /// Removes all trailing white-space characters from the current string.
         /// </summary>
         /// <returns>The string that remains after all white-space characters are removed from the end of the current string. If no characters can be trimmed from the current instance, the method returns the current instance unchanged.</returns>
         [MethodImpl(MethodImplOptions.InternalCall)]


### PR DESCRIPTION
## Description
- Properly dealing with nullable parameters in `Equals()`.
- Fix IntelliSense commetns in Trim() methods.
- Add new unit test to cover those situations described in those comments.
- Add new unit test to cover String.Format with nulls params.

## Motivation and Context
- Addressing review comments in #245.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [x] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [x] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [x] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [x] I have added new tests to cover my changes.
