### PR TITLE
Rewrote `Guid.CompareTo`

### DIFF
--- a/Tests/NFUnitTestTypes/UnitTestGuid.cs
+++ b/Tests/NFUnitTestTypes/UnitTestGuid.cs
@@ -12,17 +12,17 @@ namespace NFUnitTestTypes
         [TestMethod]
         public void Guid_Compare_To_Empty()
         {
-            var empty = Guid.Empty;
-            var notEmpty = Guid.NewGuid();
+            Guid empty = Guid.Empty;
+            Guid notEmpty = Guid.NewGuid();
             Assert.IsFalse(empty == notEmpty);
         }
 
         [TestMethod]
         public void Guid_Empty_IsAllZeros()
         {
-            var empty = Guid.Empty;
-            var bytes = empty.ToByteArray();
-            foreach (var b in bytes)
+            Guid empty = Guid.Empty;
+            byte[] bytes = empty.ToByteArray();
+            foreach (byte b in bytes)
             {
                 Assert.AreEqual((byte)0, b);
             }
@@ -31,17 +31,17 @@ namespace NFUnitTestTypes
         [TestMethod]
         public void Guid_Constructor_ByteArray_RoundTrip()
         {
-            var original = Guid.NewGuid();
-            var bytes = original.ToByteArray();
-            var roundTrip = new Guid(bytes);
+            Guid original = Guid.NewGuid();
+            byte[] bytes = original.ToByteArray();
+            Guid roundTrip = new Guid(bytes);
             Assert.AreEqual(original, roundTrip);
         }
 
         [TestMethod]
         public void Guid_Equals_And_Operator()
         {
-            var g1 = Guid.NewGuid();
-            var g2 = new Guid(g1.ToByteArray());
+            Guid g1 = Guid.NewGuid();
+            Guid g2 = new Guid(g1.ToByteArray());
             Assert.IsTrue(g1.Equals(g2));
             Assert.IsTrue(g1 == g2);
             Assert.IsFalse(g1 != g2);
@@ -50,8 +50,8 @@ namespace NFUnitTestTypes
         [TestMethod]
         public void Guid_NotEquals_And_Operator()
         {
-            var g1 = Guid.NewGuid();
-            var g2 = Guid.NewGuid();
+            Guid g1 = Guid.NewGuid();
+            Guid g2 = Guid.NewGuid();
             Assert.IsFalse(g1.Equals(g2));
             Assert.IsFalse(g1 == g2);
             Assert.IsTrue(g1 != g2);
@@ -60,25 +60,25 @@ namespace NFUnitTestTypes
         [TestMethod]
         public void Guid_ToString_And_Parse()
         {
-            var g1 = Guid.NewGuid();
-            var str = g1.ToString();
-            var g2 = new Guid(str);
+            Guid g1 = Guid.NewGuid();
+            string str = g1.ToString();
+            Guid g2 = new Guid(str);
             Assert.AreEqual(g1, g2);
         }
 
         [TestMethod]
         public void Guid_GetHashCode_Consistent()
         {
-            var g1 = Guid.NewGuid();
-            var g2 = new Guid(g1.ToByteArray());
+            Guid g1 = Guid.NewGuid();
+            Guid g2 = new Guid(g1.ToByteArray());
             Assert.AreEqual(g1.GetHashCode(), g2.GetHashCode());
         }
 
         [TestMethod]
         public void Guid_CompareTo_Object_And_Self()
         {
-            var g1 = Guid.NewGuid();
-            var g2 = new Guid(g1.ToByteArray());
+            Guid g1 = Guid.NewGuid();
+            Guid g2 = new Guid(g1.ToByteArray());
             Assert.AreEqual(0, g1.CompareTo(g2));
             Assert.AreEqual(0, g1.CompareTo((object)g2));
             Assert.AreEqual(1, g1.CompareTo(null));
@@ -87,7 +87,7 @@ namespace NFUnitTestTypes
         [TestMethod]
         public void Guid_CompareTo_InvalidType_Throws()
         {
-            var g1 = Guid.NewGuid();
+            Guid g1 = Guid.NewGuid();
             Assert.ThrowsException(typeof(ArgumentException), () =>
             {
                 g1.CompareTo("not a guid");
@@ -97,9 +97,10 @@ namespace NFUnitTestTypes
         [TestMethod]
         public void Guid_TryParseGuidWithDashes_Valid()
         {
-            var g1 = Guid.NewGuid();
-            var str = g1.ToString();
-            bool parsed = Guid.TryParse(str, out var g2);
+            Guid g1 = Guid.NewGuid();
+            string str = g1.ToString();
+            Guid g2;
+            bool parsed = Guid.TryParse(str, out g2);
             Assert.IsTrue(parsed);
             Assert.AreEqual(g1, g2);
         }
@@ -107,7 +108,8 @@ namespace NFUnitTestTypes
         [TestMethod]
         public void Guid_TryParseGuidWithDashes_Invalid()
         {
-            bool parsed = Guid.TryParse("invalid-guid", out var g2);
+            Guid g2;
+            bool parsed = Guid.TryParse("invalid-guid", out g2);
             Assert.IsFalse(parsed);
             Assert.AreEqual(Guid.Empty, g2);
         }
@@ -115,9 +117,9 @@ namespace NFUnitTestTypes
         [TestMethod]
         public void Guid_Constructor_String_WithBraces()
         {
-            var g1 = Guid.NewGuid();
-            var str = "{" + g1.ToString() + "}";
-            var g2 = new Guid(str);
+            Guid g1 = Guid.NewGuid();
+            string str = "{" + g1.ToString() + "}";
+            Guid g2 = new Guid(str);
             Assert.AreEqual(g1, g2);
         }
 
@@ -126,15 +128,50 @@ namespace NFUnitTestTypes
         {
             Assert.ThrowsException(typeof(ArgumentException), () =>
             {
-                var g = new Guid("invalid-guid");
+                Guid g = new Guid("invalid-guid");
             });
         }
 
         [TestMethod]
         public void Guid_GetHashCode_Empty()
         {
-            var empty = Guid.Empty;
+            Guid empty = Guid.Empty;
             Assert.AreEqual(0, empty.GetHashCode());
+        }
+
+        [TestMethod]
+        public void Guid_CompareTo_LessThan()
+        {
+            Guid g1 = new Guid(1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+            Guid g2 = new Guid(2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+            Assert.IsTrue(g1.CompareTo(g2) < 0, "g1 should be less than g2");
+        }
+
+        [TestMethod]
+        public void Guid_CompareTo_GreaterThan()
+        {
+            Guid g1 = new Guid(2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+            Guid g2 = new Guid(1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+            Assert.IsTrue(g1.CompareTo(g2) > 0, "g1 should be greater than g2");
+        }
+
+        [TestMethod]
+        public void Guid_CompareTo_OrdersByComponents()
+        {
+            // b component
+            Guid lo = new Guid(0, (short)1, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+            Guid hi = new Guid(0, (short)2, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+            Assert.IsTrue(lo.CompareTo(hi) < 0);
+
+            // 'a' high-bit: 0x80000001 as uint > 0x00000001; signed subtraction would overflow and give wrong sign
+            Guid bigA = new Guid(unchecked((int)0x80000001), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+            Guid smallA = new Guid(1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+            Assert.IsTrue(bigA.CompareTo(smallA) > 0);
+
+            // last byte (k)
+            Guid loK = new Guid(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1);
+            Guid hiK = new Guid(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2);
+            Assert.IsTrue(loK.CompareTo(hiK) < 0);
         }
     }
 }

--- a/nanoFramework.CoreLibrary/System/AssemblyInfo.cs
+++ b/nanoFramework.CoreLibrary/System/AssemblyInfo.cs
@@ -10,4 +10,4 @@ using System.Reflection;
 [assembly: AssemblyProduct(".NET nanoFramework mscorlib")]
 [assembly: AssemblyCopyright("Copyright (c) .NET Foundation and Contributors")]
 
-[assembly: AssemblyNativeVersion("100.22.0.3")]
+[assembly: AssemblyNativeVersion("100.22.0.4")]

--- a/nanoFramework.CoreLibrary/System/Guid.cs
+++ b/nanoFramework.CoreLibrary/System/Guid.cs
@@ -176,20 +176,55 @@ namespace System
         /// <summary>
         /// Compares the current instance with another object of the same type and returns an integer that indicates whether the current instance precedes, follows, or occurs in the same position in the sort order as the other object.
         /// </summary>
-        /// <param name="other">An object to compare with this instance.</param>
+        /// <param name="value">An object to compare with this instance.</param>
         /// <returns>A value that indicates the relative order of the objects being compared.</returns>
-        public int CompareTo(Guid other)
+        public int CompareTo(Guid value)
         {
             _data ??= new int[4];
-            other._data ??= new int[4];
-            for (int i = 0; i < 4; i++)
+            value._data ??= new int[4];
+
+            uint this0 = (uint)_data[0];
+            uint other0 = (uint)value._data[0];
+            if (this0 != other0)
             {
-                if (_data[i] != other._data[i])
-                {
-                    return _data[i] - other._data[i];
-                }
+                return this0 < other0 ? -1 : 1;
             }
+
+            uint this1 = SwapHalves((uint)_data[1]);
+            uint other1 = SwapHalves((uint)value._data[1]);
+            if (this1 != other1)
+            {
+                return this1 < other1 ? -1 : 1;
+            }
+
+            uint this2 = SwapBytes((uint)_data[2]);
+            uint other2 = SwapBytes((uint)value._data[2]);
+            if (this2 != other2)
+            {
+                return this2 < other2 ? -1 : 1;
+            }
+
+            uint this3 = SwapBytes((uint)_data[3]);
+            uint other3 = SwapBytes((uint)value._data[3]);
+            if (this3 != other3)
+            {
+                return this3 < other3 ? -1 : 1;
+            }
+
             return 0;
+        }
+
+        private static uint SwapHalves(uint value)
+        {
+            return (value << 16) | (value >> 16);
+        }
+
+        private static uint SwapBytes(uint value)
+        {
+            return ((value & 0x000000FFu) << 24) |
+                   ((value & 0x0000FF00u) << 8) |
+                   ((value & 0x00FF0000u) >> 8) |
+                   ((value & 0xFF000000u) >> 24);
         }
 
         /// <summary>


### PR DESCRIPTION
## Description
- Comparison now uses unsigned arithmetic.
- Add new unit tests to properly cover `CompareTo`.

## Motivation and Context
- Fixes issues in Guid comparison. It was comparing the packed storage words, not the logical Guid components. Also, it was using signed subtraction to determine ordering which can overflow and flip the sign.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- New unit tests added to cover this fix.
- [tested against nanoclr buildId 61138]

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [x] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [x] I have added new tests to cover my changes.
